### PR TITLE
Bug fix for /user/me - Anonymous users

### DIFF
--- a/users/tests/test_user_views.py
+++ b/users/tests/test_user_views.py
@@ -2,6 +2,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
 from django.utils.timezone import now
+from rest_framework import status
 
 from sso.models import ADFSUser
 from test_helpers.base import AliceAPIRequestFactory
@@ -54,3 +55,14 @@ class UserViewsTestCase(TestCase):
         self.assertRegex(cache_control, r'^max-age=.*$')
         self.assertEqual(resp.data['email'], 'api_debug@true')
         self.assertEqual(resp.data['last_login'], None)
+
+    @override_settings(API_DEBUG=False)
+    def test_anonymous_user_returns_403(self):
+        """
+        This should only happen if API_DEBUG is Flas, but this tests
+        that even in that scenario we define sensible behaviour
+        """
+        anon_factory = AliceAPIRequestFactory()
+        req = anon_factory.get(self.url)
+        resp = self.view(req)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/users/views.py
+++ b/users/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 
 from rest_framework import parsers, renderers, mixins, viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -57,9 +58,12 @@ class UserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 
     def get_object(self):
         u = self.request.user
-        if isinstance(u, AnonymousUser) and settings.API_DEBUG:
-            u.email = 'api_debug@true'
-            u.last_login = None
+        if isinstance(u, AnonymousUser):
+            if settings.API_DEBUG:
+                u.email = 'api_debug@true'
+                u.last_login = None
+            else:
+                raise PermissionDenied()
         return u
 
     def get_queryset(self):


### PR DESCRIPTION
This returns a 403 status if the user is not logged in
or if their session has expired when running in production mode.

Previously we were only handling Anonymous users in dev mode