### PR TITLE
Treat Closed HVC wins as non-hvc

### DIFF
--- a/data/test_settings.py
+++ b/data/test_settings.py
@@ -14,3 +14,5 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}}

--- a/mi/views/global_views.py
+++ b/mi/views/global_views.py
@@ -3,6 +3,7 @@ from mi.views.base_view import BaseWinMIView
 
 
 class GlobalWinsView(BaseWinMIView):
+
     def value_and_number(self, wins):
         confirmed_value = sum(w["total_expected_export_value"] for w in wins)
         confirmed_number = len(wins)
@@ -16,18 +17,18 @@ class GlobalWinsView(BaseWinMIView):
         hvc_unconfirmed = []
         non_hvc_confirmed = []
         non_hvc_unconfirmed = []
-        wins = list(self._wins())
-        for win in wins:
-            if win["hvc"]:
-                if self._win_status(win) == "confirmed":
-                    hvc_confirmed.append(win)
-                else:
-                    hvc_unconfirmed.append(win)
+        hvc_wins = self._hvc_wins()
+        non_hvc_wins = self._non_hvc_wins()
+        for win in hvc_wins:
+            if self._win_status(win) == "confirmed":
+                hvc_confirmed.append(win)
             else:
-                if self._win_status(win) == "confirmed":
-                    non_hvc_confirmed.append(win)
-                else:
-                    non_hvc_unconfirmed.append(win)
+                hvc_unconfirmed.append(win)
+        for win in non_hvc_wins:
+            if self._win_status(win) == "confirmed":
+                non_hvc_confirmed.append(win)
+            else:
+                non_hvc_unconfirmed.append(win)
 
         hvc_confirmed_value,hvc_confirmed_number = self.value_and_number(hvc_confirmed)
         hvc_unconfirmed_value, hvc_unconfirmed_number = self.value_and_number(hvc_unconfirmed)

--- a/mi/views/region_views.py
+++ b/mi/views/region_views.py
@@ -65,7 +65,7 @@ class BaseOverseasRegionsMIView(BaseWinMIView):
 
     def _get_region_hvc_wins(self, region):
         """ HVC wins alone for the `OverseasRegion` """
-        wins = self._wins().filter(self._region_hvc_filter(region))
+        wins = self._hvc_wins().filter(self._region_hvc_filter(region))
         return wins
 
     def _get_region_non_hvc_wins(self, region):
@@ -121,8 +121,8 @@ class OverseasRegionDetailView(BaseOverseasRegionsMIView):
         if not region:
             return self._not_found()
         results = self._region_result(region)
-        wins = self._get_region_wins(region)
-        results['wins'] = self._breakdowns(wins)
+        hvc_wins, non_hvc_wins = self._get_region_hvc_wins(region), self._get_region_non_hvc_wins(region)
+        results['wins'] = self._breakdowns(hvc_wins, non_hvc_wins=non_hvc_wins)
         self._fill_date_ranges()
         return self._success(results=results)
 
@@ -169,6 +169,7 @@ class OverseasRegionMonthsView(BaseOverseasRegionsMIView):
 
         results = self._region_result(region)
         wins = self._get_region_wins(region)
+
         results['months'] = self._month_breakdowns(wins)
         self._fill_date_ranges()
         return self._success(results)


### PR DESCRIPTION
This change is quite large and changes the way we treat wins that are
confirmed in a financial year which is not the same as the one the win
was created in.

If the confirmation year doesn't have a HVC for the same campaign id
then that HVC is considered closed.

Wins for closed hvcs should be treated the same as non-hvc wins