### PR TITLE
Allow date range param

### DIFF
--- a/mi/models.py
+++ b/mi/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils.functional import cached_property
 
 from django_countries.fields import CountryField
+from pytz import UTC
 
 from wins.models import HVC
 
@@ -238,7 +239,7 @@ class FinancialYear(models.Model):
         Pass e.g. 2016 for the 2016/17 financial year
 
         """
-        return datetime.datetime(fin_year, 4, 1)
+        return datetime.datetime(fin_year, 4, 1).replace(tzinfo=UTC)
 
     @classmethod
     def get_financial_end_date(cls, fin_year):
@@ -247,7 +248,7 @@ class FinancialYear(models.Model):
         Pass e.g. 2016 for the 2016/17 financial year
 
         """
-        return datetime.datetime(fin_year + 1, 3, 31, 23, 59, 59)
+        return datetime.datetime.combine(datetime.date(fin_year + 1, 3, 31), datetime.datetime.max.time()).replace(tzinfo=UTC)
 
     @property
     def start(self):

--- a/mi/serializers.py
+++ b/mi/serializers.py
@@ -1,5 +1,12 @@
-from rest_framework.fields import SerializerMethodField
-from rest_framework.serializers import ModelSerializer
+import datetime
+
+from django.utils.dateparse import parse_datetime, parse_date
+from pytz import UTC
+from rest_framework.exceptions import ValidationError
+from rest_framework.fields import SerializerMethodField, DateTimeField, empty
+from rest_framework.serializers import ModelSerializer, Serializer
+from rest_framework.settings import api_settings
+from rest_framework.utils import humanize_datetime
 
 from .models import SectorTeam, OverseasRegion, ParentSector, OverseasRegionGroup
 
@@ -52,3 +59,80 @@ class ParentSectorSerializer(ModelSerializer):
             'id',
             'name',
         ]
+
+
+class DateTimeOrDateThatDefaultsTimeField(DateTimeField):
+
+    default_time = None
+
+    def __init__(self, default_time=None, format=empty, default_timezone=None, *args, **kwargs):
+        self.default_time = default_time
+        super().__init__(format=format, input_formats=None, default_timezone=default_timezone, *args, **kwargs)
+
+    def to_internal_value(self, value):
+        input_formats = getattr(self, 'input_formats', api_settings.DATETIME_INPUT_FORMATS)
+
+        if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime):
+            value = datetime.datetime.combine(value, self.default_time).replace(tzinfo=UTC)
+
+        if isinstance(value, datetime.datetime):
+            return self.enforce_timezone(value)
+
+        try:
+            parsed = parse_datetime(value)
+        except (ValueError, TypeError):
+            pass
+        else:
+            if parsed is not None:
+                return self.enforce_timezone(parsed)
+            else:
+                try:
+                    parsed = datetime.datetime.combine(parse_date(value), self.default_time)
+                except (ValueError, TypeError):
+                    pass
+                else:
+                    if parsed is not None:
+                        return self.enforce_timezone(parsed)
+
+        humanized_format = humanize_datetime.datetime_formats(input_formats)
+        self.fail('invalid', format=humanized_format)
+
+class DateRangeSerializer(Serializer):
+
+    date_start = DateTimeOrDateThatDefaultsTimeField(
+        default_time=datetime.datetime.min.time(),
+        required=False,
+        write_only=True,
+        default_timezone=UTC
+    )
+
+    date_end = DateTimeOrDateThatDefaultsTimeField(
+        default_time=datetime.datetime.max.time(),
+        required=False,
+        write_only=True,
+        default_timezone=UTC
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.financial_year = kwargs.pop('financial_year')
+        super().__init__(*args, **kwargs)
+
+    def validate_date_start(self, value):
+        return self.is_inside_financial_year(value)
+
+    def validate_date_end(self, value):
+        return self.is_inside_financial_year(value)
+
+    def is_inside_financial_year(self, value):
+        end = self.financial_year.end
+        start = self.financial_year.start
+        if not end >= value >= start:
+            raise ValidationError(
+                "{value} must be in Financial Year: {fin_year}. Between {start} and {end}".format(
+                    value=value,
+                    fin_year=self.financial_year,
+                    start=start,
+                    end=end,
+                )
+            )
+        return value

--- a/mi/tests/test_global_views.py
+++ b/mi/tests/test_global_views.py
@@ -9,7 +9,7 @@ from fixturedb.factories.win import create_win_factory
 from mi.tests.base_test_case import MiApiViewsWithWinsBaseTestCase, MiApiViewsBaseTestCase
 
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
+@freeze_time(MiApiViewsBaseTestCase.frozen_date_17 + datetime.timedelta(weeks=5))
 class GlobalWinsViewTestCase(MiApiViewsWithWinsBaseTestCase):
     """ Tests to test global win aggregate view `GlobalWinsView` """
 

--- a/mi/tests/test_hvc_views.py
+++ b/mi/tests/test_hvc_views.py
@@ -19,6 +19,7 @@ from wins.factories import NotificationFactory, HVCFactory
 from wins.models import Notification, _get_open_hvcs, normalize_year, HVC
 
 
+@freeze_time(datetime.datetime(2017, 5, 30, tzinfo=get_current_timezone()))
 class HVCBaseViewTestCase(MiApiViewsWithWinsBaseTestCase):
     """ HVC Detail page base test case """
     view_base_url = reverse('mi:hvc_campaign_detail', kwargs={"campaign_id": "E017"})
@@ -33,7 +34,6 @@ class HVCBaseViewTestCase(MiApiViewsWithWinsBaseTestCase):
         return '{base}?year={year}'.format(base=base_url, year=year)
 
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
 class HVCDetailsTestCase(HVCBaseViewTestCase):
     TEST_CAMPAIGN_ID = "E017"
     TARGET_E017_17 = 30000000
@@ -308,6 +308,7 @@ class HVCDetailsTestCase(HVCBaseViewTestCase):
         self.assertEqual(cen_response["wins"]["totals"]["value"]["grand_total"], 0)
         self.assertEqual(cen_response["wins"]["totals"]["number"]["grand_total"], 0)
 
+    @freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
     def test_details_cen_hvc_win_unconfirmed_in_2016_appears_in_2017(self):
         self._create_hvc_win(
             hvc_code='E017',

--- a/mi/tests/test_hvcgroup_views.py
+++ b/mi/tests/test_hvcgroup_views.py
@@ -737,6 +737,7 @@ class HVCGroupBaseViewTestCase(MiApiViewsWithWinsBaseTestCase):
     win_date_2017 = datetime.datetime(2017, 5, 25, tzinfo=get_current_timezone())
     win_date_2016 = datetime.datetime(2016, 5, 25, tzinfo=get_current_timezone())
     fy_2016_last_date = datetime.datetime(2017, 3, 31, tzinfo=get_current_timezone())
+    frozen_date_17 = datetime.datetime(2017, 5, 31, tzinfo=get_current_timezone())
 
     def get_url_for_year(self, year, base_url=None):
         if not base_url:
@@ -744,7 +745,7 @@ class HVCGroupBaseViewTestCase(MiApiViewsWithWinsBaseTestCase):
         return '{base}?year={year}'.format(base=base_url, year=year)
 
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
+@freeze_time(HVCGroupBaseViewTestCase.frozen_date_17)
 class HVCGroupWinTableTestCase(HVCGroupBaseViewTestCase):
     TEST_CAMPAIGN_ID = "E001"
     win_table_url = reverse('mi:hvc_group_win_table', kwargs={"group_id": 4})

--- a/mi/tests/test_region_views.py
+++ b/mi/tests/test_region_views.py
@@ -114,12 +114,14 @@ class OverseasRegionGroupListViewTestCase(MiApiViewsBaseTestCase):
         self.assertResponse()
 
 
+@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
 class OverseasRegionBaseViewTestCase(MiApiViewsWithWinsBaseTestCase):
     view_base_url = reverse('mi:overseas_regions')
     export_value = 100000
-    win_date_2017 = datetime.datetime(2017, 5, 25, tzinfo=get_current_timezone())
-    win_date_2016 = datetime.datetime(2016, 5, 25, tzinfo=get_current_timezone())
+    win_date_2017 = datetime.datetime(2017, 4, 25, tzinfo=get_current_timezone())
+    win_date_2016 = datetime.datetime(2016, 4, 25, tzinfo=get_current_timezone())
     fy_2016_last_date = datetime.datetime(2017, 3, 31, tzinfo=get_current_timezone())
+    frozen_date_17 = datetime.datetime(2017, 5, 30, tzinfo=get_current_timezone())
 
     def get_url_for_year(self, year, base_url=None):
         if not base_url:
@@ -188,7 +190,7 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
 
     def test_overview_value_1_win(self):
         w1 = self._create_hvc_win(
-            hvc_code='E016', win_date=now(),
+            hvc_code='E016', win_date=self.win_date_2017,
             confirm=True,
             fin_year=2017,
             export_value=self.export_value
@@ -203,14 +205,14 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
     def test_overview_value_2_wins_same_region(self):
         w1 = self._create_hvc_win(
             hvc_code='E016',
-            win_date=now(),
+            win_date=self.win_date_2017,
             confirm=True,
             fin_year=2017,
             export_value=self.export_value
         )
         w2 = self._create_hvc_win(
             hvc_code='E016',
-            win_date=now(),
+            win_date=self.win_date_2017,
             confirm=True,
             fin_year=2017,
             export_value=1
@@ -224,11 +226,11 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
 
     def test_overview_value_2_wins_different_regions(self):
         w1 = self._create_hvc_win(
-            hvc_code='E016', win_date=now(), confirm=True,
+            hvc_code='E016', win_date=self.win_date_2017, confirm=True,
             fin_year=2017, export_value=self.export_value
         )
         w2 = self._create_hvc_win(
-            hvc_code='E119', win_date=now(),
+            hvc_code='E119', win_date=self.win_date_2017,
             confirm=True, fin_year=2017, export_value=1
         )
         self.assertEqual(w1.country.code, w2.country.code)
@@ -243,11 +245,11 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
 
     def test_overview_1_unconfirmed_and_1_confirmed_same_year(self):
         w1 = self._create_hvc_win(
-            hvc_code='E016', win_date=now(), confirm=True,
+            hvc_code='E016', win_date=self.win_date_2017, confirm=True,
             fin_year=2017, export_value=self.export_value
         )
         w2 = self._create_hvc_win(
-            hvc_code='E016', win_date=now(), confirm=False,
+            hvc_code='E016', win_date=self.win_date_2017, confirm=False,
             fin_year=2017, export_value=1
         )
         self.assertEqual(w1.country.code, w2.country.code)
@@ -261,7 +263,7 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
 
     def test_overview_1_unconfirmed_in_current_year_should_not_show_up_in_last_year(self):
         w1 = self._create_hvc_win(
-            hvc_code='E016', win_date=now(),
+            hvc_code='E016', win_date=self.win_date_2017,
             confirm=False,
             fin_year=2017,
             export_value=self.export_value
@@ -338,7 +340,7 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
     # Non HVC
     def test_non_hvc_win_in_overview_confirmed_current_year(self):
         w1 = self._create_non_hvc_win(
-            win_date=self.frozen_date_17, export_value=self.export_value,
+            win_date=self.win_date_2017, export_value=self.export_value,
             confirm=True, country='CA', fin_year=2017
         )
         self.url = self.get_url_for_year(2017)
@@ -356,7 +358,7 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
 
     def test_non_hvc_win_in_overview_unconfirmed_current_year(self):
         w1 = self._create_non_hvc_win(
-            win_date=self.frozen_date_17, export_value=self.export_value,
+            win_date=self.win_date_2017, export_value=self.export_value,
             confirm=False, country='CA', fin_year=2017
         )
         self.url = self.get_url_for_year(2017)
@@ -374,14 +376,14 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
 
     def test_2_non_hvc_win_in_overview_both_confirmed_current_year(self):
         self._create_non_hvc_win(
-            win_date=self.frozen_date_17,
+            win_date=self.win_date_2017,
             export_value=self.export_value + 1,
             confirm=True,
             country='CA',
             fin_year=2017
         )
         self._create_non_hvc_win(
-            win_date=self.frozen_date_17,
+            win_date=self.win_date_2017,
             export_value=self.export_value - 1,
             confirm=True,
             country='CA',
@@ -405,14 +407,14 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
 
     def test_2_non_hvc_win_in_overview_confirmed_and_unconfirmed_current_year(self):
         w1 = self._create_non_hvc_win(
-            win_date=self.frozen_date_17,
+            win_date=self.win_date_2017,
             export_value=self.export_value + 1,
             confirm=True,
             country='CA',
             fin_year=2017
         )
         w2 = self._create_non_hvc_win(
-            win_date=self.frozen_date_17,
+            win_date=self.win_date_2017,
             export_value=self.export_value - 1,
             confirm=False,
             country='CA',
@@ -493,7 +495,6 @@ class OverseasRegionOverviewTestCase(OverseasRegionBaseViewTestCase):
         )
 
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
 class OverseasRegionCampaignsTestCase(OverseasRegionBaseViewTestCase):
     list_regions_base_url = reverse('mi:overseas_regions')
     view_base_url = reverse('mi:overseas_region_campaigns', kwargs={"region_id": 10})
@@ -1298,7 +1299,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
     def test_details_cen_hvc_win_for_2017_in_2017(self):
         self._create_hvc_win(
             hvc_code='E017',
-            win_date=now(),
+            win_date=self.win_date_2017,
             confirm=True,
             fin_year=2017,
             export_value=self.export_value,
@@ -1316,7 +1317,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
     def test_details_cen_hvc_win_for_2017_in_2016(self):
         self._create_hvc_win(
             hvc_code='E017',
-            win_date=now(),
+            win_date=self.win_date_2017,
             confirm=True,
             fin_year=2017,
             export_value=self.export_value,
@@ -1480,7 +1481,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
     def test_details_cen_hvc_win_unconfirmed_in_2016_appears_in_2017(self):
         self._create_hvc_win(
             hvc_code='E017',
-            win_date=self.win_date_2016,
+            win_date=self.frozen_date,
             confirm=False,
             fin_year=2016,
             export_value=self.export_value,
@@ -1534,7 +1535,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
     def test_details_unconfirmed_hvc_win_last_year_should_show_up_in_new_region_if_country_has_moved_regions(self):
         self._create_hvc_win(
             hvc_code='E017',
-            win_date=self.win_date_2016,
+            win_date=self.frozen_date,
             confirm=False,
             fin_year=2016,
             export_value=self.export_value,
@@ -1572,7 +1573,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
     # Non-HVC
     def test_details_cen_non_hvc_win_for_2017_in_2017(self):
         self._create_non_hvc_win(
-            win_date=now(),
+            win_date=self.win_date_2017,
             confirm=True,
             fin_year=2017,
             export_value=self.export_value,
@@ -1589,7 +1590,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
 
     def test_details_cen_non_hvc_win_for_2017_in_2016(self):
         self._create_non_hvc_win(
-            win_date=now(),
+            win_date=self.win_date_2017,
             confirm=True,
             fin_year=2017,
             export_value=self.export_value,
@@ -1744,7 +1745,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
 
     def test_details_cen_non_hvc_win_unconfirmed_in_2016_appears_in_2017(self):
         self._create_non_hvc_win(
-            win_date=self.win_date_2016,
+            win_date=self.frozen_date,
             confirm=False,
             fin_year=2016,
             export_value=self.export_value,
@@ -1796,7 +1797,7 @@ class OverseasRegionDetailsTestCase(OverseasRegionBaseViewTestCase):
 
     def test_details_unconfirmed_non_hvc_win_last_year_should_show_up_in_new_region_if_country_has_moved_regions(self):
         self._create_non_hvc_win(
-            win_date=self.win_date_2016,
+            win_date=self.frozen_date,
             confirm=False,
             fin_year=2016,
             export_value=self.export_value,
@@ -1863,7 +1864,7 @@ class OverseasRegionMonthsTestCase(OverseasRegionBaseViewTestCase):
         export_value = 123456
 
         self._create_hvc_win(
-            hvc_code='E011', win_date=now(),
+            hvc_code='E011', win_date=now(), response_date=now(),
             confirm=True, fin_year=2017, export_value=export_value)
 
         self.url = self.get_url_for_year(2017)
@@ -1886,7 +1887,7 @@ class OverseasRegionMonthsTestCase(OverseasRegionBaseViewTestCase):
         export_value = 123456
 
         self._create_hvc_win(
-            hvc_code='E011', win_date=now(),
+            hvc_code='E011', win_date=now(), response_date=now(),
             confirm=True, fin_year=2017, export_value=export_value)
 
         self._create_hvc_win(
@@ -2110,10 +2111,8 @@ class OverseasRegionsTopNonHvcWinsTestCase(OverseasRegionBaseViewTestCase):
             data[1]['totalValue']
         )
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
+@freeze_time(OverseasRegionBaseViewTestCase.frozen_date_17)
 class OverseasRegionsWinTableTestCase(OverseasRegionBaseViewTestCase):
-    win_date_2017 = datetime.datetime(2017, 5, 25, tzinfo=get_current_timezone())
-    win_date_2016 = datetime.datetime(2016, 5, 25, tzinfo=get_current_timezone())
     export_value = 100000
 
     @classmethod

--- a/mi/tests/test_sector_team_months.py
+++ b/mi/tests/test_sector_team_months.py
@@ -11,7 +11,7 @@ from mi.tests.test_sector_views import SectorTeamBaseTestCase
 from mi.utils import month_iterator
 
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date)
+@freeze_time(datetime.datetime(2017, 1, 31))
 class SectorTeamMonthlyViewsTestCase(SectorTeamBaseTestCase):
     """
     Tests covering SectorTeam Campaigns API endpoint

--- a/mi/tests/test_sector_views.py
+++ b/mi/tests/test_sector_views.py
@@ -21,6 +21,7 @@ from wins.models import HVC, Notification
 
 
 class SectorTeamBaseTestCase(MiApiViewsWithWinsBaseTestCase):
+    frozen_date_17 = datetime.datetime(2017, 5, 28, tzinfo=get_current_timezone())
 
     def setUp(self):
         super().setUp()
@@ -853,7 +854,7 @@ class SectorTeamCampaignViewsTestCase(SectorTeamBaseTestCase):
         self.assertEqual(campaign_data["totals"]["hvc"]["value"]["unconfirmed"], 1000000)
         self.assertEqual(campaign_data["totals"]["hvc"]["value"]["total"], 2000000)
 
-    @freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
+    @freeze_time(SectorTeamBaseTestCase.frozen_date_17)
     def test_campaign_hvc_win_added_previous_fy_but_no_hvc_this_year_should_be_non_hvc(self):
         self.url = reverse("mi:sector_team_campaigns", kwargs={"team_id": 1}) + "?year=2017"
         t = Target.objects.get(campaign_id=self.TEST_CAMPAIGN_ID, financial_year_id=2017)
@@ -862,7 +863,7 @@ class SectorTeamCampaignViewsTestCase(SectorTeamBaseTestCase):
             hvc_code=self.TEST_CAMPAIGN_ID,
             export_value=100000,
             response_date=self.frozen_date_17 + relativedelta(weeks=-1),
-            win_date=self.frozen_date_17 + relativedelta(months=-10),
+            win_date=self.frozen_date_17 + relativedelta(months=-9),
             fin_year=2016,
             agree_with_win=True,
             confirm=True
@@ -881,7 +882,7 @@ class SectorTeamCampaignViewsTestCase(SectorTeamBaseTestCase):
             0
         )
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
+@freeze_time(SectorTeamBaseTestCase.frozen_date_17)
 class SectorOverviewTestCase(SectorTeamBaseTestCase):
     url = reverse('mi:sector_teams_overview') + "?year=2017"
     TEST_CAMPAIGN_ID = 'E006'
@@ -898,7 +899,7 @@ class SectorOverviewTestCase(SectorTeamBaseTestCase):
             hvc_code=self.TEST_CAMPAIGN_ID,
             export_value=100000,
             response_date=self.frozen_date_17 + relativedelta(weeks=-1),
-            win_date=self.frozen_date_17 + relativedelta(months=-10),
+            win_date=self.frozen_date_17 + relativedelta(months=-9),
             fin_year=2016,
             agree_with_win=True,
             confirm=True
@@ -1078,7 +1079,7 @@ class SectorTeamTopNonHvcTestCase(SectorTeamBaseTestCase):
         self.assertTrue(response_decoded[2]["averageWinValue"] >= response_decoded[3]["averageWinValue"])
         self.assertTrue(response_decoded[3]["averageWinValue"] >= response_decoded[4]["averageWinValue"])
 
-@freeze_time(MiApiViewsBaseTestCase.frozen_date_17)
+@freeze_time(SectorTeamBaseTestCase.frozen_date_17)
 class SectorTeamWinTableTestCase(SectorTeamBaseTestCase):
     win_date_2017 = datetime.datetime(2017, 5, 25, tzinfo=get_current_timezone())
     win_date_2016 = datetime.datetime(2016, 5, 25, tzinfo=get_current_timezone())

--- a/mi/tests/test_serializer.py
+++ b/mi/tests/test_serializer.py
@@ -1,0 +1,39 @@
+from datetime import datetime, date
+
+from django.test import SimpleTestCase
+
+from mi.serializers import DateRangeSerializer
+
+
+class FakeFinancialYear(object):
+    start = datetime.combine(date(2017, 4, 1), datetime.min.time())
+    end = datetime.combine(date(2018, 3, 31), datetime.max.time())
+
+class DateRangeSerializerTestCase(SimpleTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.FAKE_YEAR = FakeFinancialYear()
+
+    def test_parses_datetime_start_and_end(self):
+        input_data = {'2017-4-'}
+        expected_data = {}
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR)
+
+        pass
+
+    def test_parses_datetime_only_start_no_end(self):
+        pass
+
+    def test_parses_datetime_only_end_no_start(self):
+        pass
+
+    def test_parses_date_start_and_end(self):
+        pass
+
+    def test_parses_date_only_start_no_end(self):
+        pass
+
+    def test_parses_date_only_end_no_start(self):
+        pass

--- a/mi/tests/test_serializer.py
+++ b/mi/tests/test_serializer.py
@@ -1,13 +1,15 @@
-from datetime import datetime, date
+from datetime import date
 
 from django.test import SimpleTestCase
 
 from mi.serializers import DateRangeSerializer
+from mi.tests.utils import datetime_factory, MIN, MAX
 
 
 class FakeFinancialYear(object):
-    start = datetime.combine(date(2017, 4, 1), datetime.min.time())
-    end = datetime.combine(date(2018, 3, 31), datetime.max.time())
+    start = datetime_factory(date(2017, 4, 1), MIN)
+    end = datetime_factory(date(2018, 3, 31), MAX)
+
 
 class DateRangeSerializerTestCase(SimpleTestCase):
 
@@ -17,23 +19,138 @@ class DateRangeSerializerTestCase(SimpleTestCase):
         cls.FAKE_YEAR = FakeFinancialYear()
 
     def test_parses_datetime_start_and_end(self):
-        input_data = {'2017-4-'}
-        expected_data = {}
-        s = DateRangeSerializer(financial_year=self.FAKE_YEAR)
+        input_data = {
+            'date_start': '2017-4-1T00:00Z',
+            'date_end': '2017-4-2T23:59:59.999999Z'
+        }
+        expected_data = {
+            'date_start': datetime_factory(date(2017, 4, 1), MIN),
+            'date_end': datetime_factory(date(2017, 4, 2), MAX),
+        }
 
-        pass
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
 
     def test_parses_datetime_only_start_no_end(self):
-        pass
+        input_data = {
+            'date_start': '2017-4-1T00:00Z',
+        }
+        expected_data = {
+            'date_start': datetime_factory(date(2017, 4, 1), MIN),
+        }
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
 
     def test_parses_datetime_only_end_no_start(self):
-        pass
+        input_data = {
+            'date_end': '2017-4-2T23:59:59.999999Z'
+        }
+        expected_data = {
+            'date_end': datetime_factory(date(2017, 4, 2), MAX),
+        }
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
 
     def test_parses_date_start_and_end(self):
-        pass
+        input_data = {
+            'date_start': '2017-4-1',
+            'date_end': '2017-4-2'
+        }
+        expected_data = {
+            'date_start': datetime_factory(date(2017, 4, 1), MIN),
+            'date_end': datetime_factory(date(2017, 4, 2), MAX),
+        }
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
 
     def test_parses_date_only_start_no_end(self):
-        pass
+        input_data = {
+            'date_start': '2017-4-1',
+        }
+        expected_data = {
+            'date_start': datetime_factory(date(2017, 4, 1), MIN),
+        }
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
 
     def test_parses_date_only_end_no_start(self):
-        pass
+        input_data = {
+            'date_end': '2017-4-2'
+        }
+        expected_data = {
+            'date_end': datetime_factory(date(2017, 4, 2), MAX),
+        }
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
+
+    def test_no_inputs_is_valid(self):
+        input_data = {}
+        expected_data = {}
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
+
+    def test_ignores_extra_inputs_is_valid(self):
+        input_data = {'foo': 'bar'}
+        expected_data = {}
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
+
+        input_data = {
+            'date_start': '2017-4-1',
+            'date_end': '2017-4-2',
+            'foo': 'bar'
+        }
+        expected_data = {
+            'date_start': datetime_factory(date(2017, 4, 1), MIN),
+            'date_end': datetime_factory(date(2017, 4, 2), MAX),
+        }
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertTrue(s.is_valid())
+        self.assertDictEqual(s.validated_data, expected_data)
+
+    def test_invalid_start_date_format_returns_format_error(self):
+        input_data = {
+            'date_start': '2017.4.1',
+        }
+
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertFalse(s.is_valid())
+        self.assertTrue('date_start' in s.errors)
+        self.assertTrue('format' in s.errors['date_start'][0])
+
+    def test_invalid_end_date_format_returns_format_error(self):
+        input_data = {
+            'date_end': '2017.4.1',
+        }
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertFalse(s.is_valid())
+        self.assertTrue('date_end' in s.errors)
+        self.assertTrue('format' in s.errors['date_end'][0])
+
+    def test_invalid_start_and_end_date_format_returns_both_format_errors(self):
+        input_data = {
+            'date_start': '207.4.1',
+            'date_end': '2017.4.1',
+        }
+        s = DateRangeSerializer(financial_year=self.FAKE_YEAR, data=input_data)
+        self.assertFalse(s.is_valid())
+        self.assertTrue('date_start' in s.errors)
+        self.assertTrue('format' in s.errors['date_start'][0])
+        self.assertTrue('date_end' in s.errors)
+        self.assertTrue('format' in s.errors['date_end'][0])

--- a/mi/tests/test_utils.py
+++ b/mi/tests/test_utils.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import datetime, date
 
 from django.test import TestCase
 
 from freezegun import freeze_time
+from pytz import UTC
 
 from mi.models import FinancialYear
 from mi.utils import month_iterator
@@ -14,12 +15,13 @@ class UtilTests(TestCase):
     @freeze_time("2016-05-01")
     def test_financial_year_start_date(self):
         fin_year = FinancialYear.objects.get(id=2016)
-        self.assertEqual(fin_year.start, datetime(2016, 4, 1))
+        self.assertEqual(fin_year.start, datetime(2016, 4, 1, tzinfo=UTC))
 
     @freeze_time("2016-05-01")
     def test_financial_year_end_date(self):
         fin_year = FinancialYear.objects.get(id=2016)
-        self.assertEqual(fin_year.end, datetime(2017, 3, 31, 23, 59, 59))
+        end_dt = datetime.combine(date(2017, 3, 31), datetime.max.time()).replace(tzinfo=UTC)
+        self.assertEqual(fin_year.end, end_dt)
 
     @freeze_time("2016-05-01")
     def test_month_iterator_with_current_date_as_end_date(self):

--- a/mi/tests/utils.py
+++ b/mi/tests/utils.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from pytz import UTC
+
+c = datetime.combine
+
+
+def datetime_factory(date, time):
+    return c(date, time).replace(tzinfo=UTC)
+
+
+MIN = datetime.min.time()
+MAX = datetime.max.time()

--- a/mi/views/base_view.py
+++ b/mi/views/base_view.py
@@ -147,8 +147,8 @@ class BaseWinMIView(BaseMIView):
         """
         # get Wins where the customer responded in the given FY
         win_filter = Q(confirmation__created__range=(
-            self.fin_year.start,
-            self.fin_year.end,
+            self._date_range_start(),
+            self._date_range_end()
         ))
 
         # if we're in the current FY, also include unconfirmed Wins

--- a/mi/views/global_views.py
+++ b/mi/views/global_views.py
@@ -10,9 +10,6 @@ class GlobalWinsView(BaseWinMIView):
         return confirmed_value, confirmed_number
 
     def get(self, request):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
         hvc_confirmed = []
         hvc_unconfirmed = []
         non_hvc_confirmed = []
@@ -81,5 +78,4 @@ class GlobalWinsView(BaseWinMIView):
                 }
             }
         }
-        self._fill_date_ranges()
         return self._success(results)

--- a/mi/views/hvc_views.py
+++ b/mi/views/hvc_views.py
@@ -148,25 +148,6 @@ class HVCWinsByMarketSectorView(BaseHVCDetailView):
 class HVCWinTableView(BaseHVCDetailView):
     """ Wins for table view for HVC"""
     def get(self, request, campaign_id):
-        def confirmed_date(win):
-            if not win["confirmation__created"]:
-                return None
-            else:
-                return win["confirmation__created"]
-
-        def status(win):
-            if not win["notifications__created"]:
-                return "email_not_sent"
-            elif not win["confirmation__created"]:
-                return "response_not_received"
-            elif win["confirmation__agree_with_win"]:
-                return "customer_confirmed"
-            else:
-                return "customer_rejected"
-
-        def credit(win):
-            return self._win_status(win) == "confirmed"
-
         campaign = self._get_campaign(campaign_id)
         if not campaign:
             return self._not_found()

--- a/mi/views/hvcgroup_views.py
+++ b/mi/views/hvcgroup_views.py
@@ -26,10 +26,6 @@ class BaseHVCGroupMIView(BaseSectorMIView):
 
 class HVCGroupsListView(BaseHVCGroupMIView):
     def get(self, request):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         results = [
             {
                 'id': hvc_group.id,
@@ -44,10 +40,6 @@ class HVCGroupDetailView(BaseHVCGroupMIView):
     """ HVC Group details with name, targets and win-breakdown """
 
     def get(self, request, group_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         group = self._get_hvc_group(group_id)
         if not group:
             return self._invalid('hvc group not found')
@@ -55,7 +47,6 @@ class HVCGroupDetailView(BaseHVCGroupMIView):
         results = self._group_result(group)
         wins = self._get_group_wins(group)
         results['wins'] = self._breakdowns(wins, include_non_hvc=False)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -95,9 +86,6 @@ class HVCGroupMonthsView(BaseHVCGroupMIView):
         return sorted(month_to_wins, key=lambda tup: tup[0])
 
     def get(self, request, group_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
 
         group = self._get_hvc_group(group_id)
         if not group:
@@ -106,7 +94,6 @@ class HVCGroupMonthsView(BaseHVCGroupMIView):
         results = self._group_result(group)
         wins = self._get_group_wins(group)
         results['months'] = self._month_breakdowns(wins)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -137,17 +124,12 @@ class HVCGroupCampaignsView(BaseHVCGroupMIView):
         return sorted_campaigns
 
     def get(self, request, group_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         group = self._get_hvc_group(group_id)
         if not group:
             return self._invalid('hvc group not found')
 
         results = self._group_result(group)
         results['campaigns'] = self._campaign_breakdowns(group)
-        self._fill_date_ranges()
         return self._success(results)
 
 class HVCGroupWinTableView(BaseHVCGroupMIView):

--- a/mi/views/hvcgroup_views.py
+++ b/mi/views/hvcgroup_views.py
@@ -134,9 +134,6 @@ class HVCGroupCampaignsView(BaseHVCGroupMIView):
 
 class HVCGroupWinTableView(BaseHVCGroupMIView):
     def get(self, request, group_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
         group = self._get_hvc_group(group_id)
         if not group:
             return self._not_found()
@@ -148,5 +145,4 @@ class HVCGroupWinTableView(BaseHVCGroupMIView):
             },
             "wins": self._win_table_wins(self._get_group_wins(group))
         }
-        self._fill_date_ranges()
         return self._success(results)

--- a/mi/views/region_views.py
+++ b/mi/views/region_views.py
@@ -20,9 +20,6 @@ class BaseOverseasRegionGroupMIView(BaseMIView):
         return [OverseasRegionGroupSerializer(instance=x, year=self.fin_year).data for x in self.get_queryset().order_by('name')]
 
     def get(self, request):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
         return self._success(self.get_results())
 
 class BaseOverseasRegionsMIView(BaseWinMIView):
@@ -95,10 +92,6 @@ class OverseasRegionsListView(BaseOverseasRegionsMIView):
     """ List all Overseas Regions """
 
     def get(self, request):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         results = [
             {
                 'id': region.id,
@@ -113,17 +106,12 @@ class OverseasRegionDetailView(BaseOverseasRegionsMIView):
     """ Overseas Region detail view along with win-breakdown"""
 
     def get(self, request, region_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         region = self._get_region(region_id)
         if not region:
             return self._not_found()
         results = self._region_result(region)
         hvc_wins, non_hvc_wins = self._get_region_hvc_wins(region), self._get_region_non_hvc_wins(region)
         results['wins'] = self._breakdowns(hvc_wins, non_hvc_wins=non_hvc_wins)
-        self._fill_date_ranges()
         return self._success(results=results)
 
 
@@ -159,10 +147,6 @@ class OverseasRegionMonthsView(BaseOverseasRegionsMIView):
         return sorted(month_to_wins, key=lambda tup: tup[0])
 
     def get(self, request, region_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         region = self._get_region(region_id)
         if not region:
             return self._invalid('region not found')
@@ -171,7 +155,6 @@ class OverseasRegionMonthsView(BaseOverseasRegionsMIView):
         wins = self._get_region_wins(region)
 
         results['months'] = self._month_breakdowns(wins)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -194,15 +177,12 @@ class OverseasRegionCampaignsView(BaseOverseasRegionsMIView):
         return sorted_campaigns
 
     def get(self, request, region_id):
-        self._handle_fin_year(request)
-
         region = self._get_region(region_id)
         if not region:
             return self._invalid('region not found')
 
         results = self._region_result(region)
         results['campaigns'] = self._campaign_breakdowns(region)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -210,16 +190,12 @@ class OverseasRegionsTopNonHvcWinsView(BaseOverseasRegionsMIView):
     """ Top n HVCs with win-breakdown for given Overseas Region"""
 
     def get(self, request, region_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
         region = self._get_region(region_id)
         if not region:
             return self._invalid('region not found')
 
         non_hvc_wins_qs = self._get_region_non_hvc_wins(region)
         results = self._top_non_hvc(non_hvc_wins_qs)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -272,12 +248,7 @@ class OverseasRegionOverviewView(BaseOverseasRegionsMIView):
         return result
 
     def get(self, request):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         result = [self._region_data(region) for region in self._regions_for_fin_year()]
-        self._fill_date_ranges()
         return self._success(result)
 
 class OverseasRegionWinTableView(BaseOverseasRegionsMIView):

--- a/mi/views/region_views.py
+++ b/mi/views/region_views.py
@@ -253,9 +253,6 @@ class OverseasRegionOverviewView(BaseOverseasRegionsMIView):
 
 class OverseasRegionWinTableView(BaseOverseasRegionsMIView):
     def get(self, request, region_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
         region = self._get_region(region_id)
         if not region:
             return self._not_found()
@@ -267,5 +264,4 @@ class OverseasRegionWinTableView(BaseOverseasRegionsMIView):
             },
             "wins": self._win_table_wins(self._get_region_hvc_wins(region), self._get_region_non_hvc_wins(region))
         }
-        self._fill_date_ranges()
         return self._success(results)

--- a/mi/views/sector_views.py
+++ b/mi/views/sector_views.py
@@ -346,12 +346,8 @@ class SectorTeamsOverviewView(BaseSectorMIView):
         return self._success(sorted(result, key=itemgetter('name')))
 
 class SectorTeamWinTableView(BaseSectorMIView):
-    """ """
+
     def get(self, request, team_id):
-        """ """
-        response = self._handle_fin_year(request)
-        if response:
-            return response
         team = self._get_team(team_id)
         if not team:
             return self._not_found()
@@ -363,5 +359,4 @@ class SectorTeamWinTableView(BaseSectorMIView):
             },
             "wins": self._win_table_wins(self._get_hvc_wins(team), self._get_non_hvc_wins(team))
         }
-        self._fill_date_ranges()
         return self._success(results)

--- a/mi/views/sector_views.py
+++ b/mi/views/sector_views.py
@@ -117,16 +117,11 @@ class TopNonHvcSectorCountryWinsView(BaseSectorMIView):
     """ Sector Team non-HVC Win data broken down by country """
 
     def get(self, request, team_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         team = self._get_team(team_id)
         if not team:
             return self._invalid('team not found')
         non_hvc_wins_qs = self._get_non_hvc_wins(team)
         results = self._top_non_hvc(non_hvc_wins_qs)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -146,10 +141,6 @@ class SectorTeamsListView(BaseSectorMIView):
         return sorted(results, key=itemgetter('name'))
 
     def get(self, request):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         results = [
             {
                 'id': sector_team.id,
@@ -165,16 +156,12 @@ class SectorTeamDetailView(BaseSectorMIView):
     """ Sector Team name, targets and win-breakdown """
 
     def get(self, request, team_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
         team = self._get_team(team_id)
         if not team:
             return self._invalid('team not found')
 
         results = self._sector_result(team)
         results['wins'] = self._team_wins_breakdown(team)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -210,10 +197,6 @@ class SectorTeamMonthsView(BaseSectorMIView):
         return sorted(month_to_wins, key=lambda tup: tup[0])
 
     def get(self, request, team_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         team = self._get_team(team_id)
         if not team:
             return self._invalid('team not found')
@@ -221,7 +204,6 @@ class SectorTeamMonthsView(BaseSectorMIView):
         results = self._sector_result(team)
         wins = self._get_all_wins(team)
         results['months'] = self._month_breakdowns(wins)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -246,17 +228,12 @@ class SectorTeamCampaignsView(BaseSectorMIView):
         return sorted_campaigns
 
     def get(self, request, team_id):
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         team = self._get_team(team_id)
         if not team:
             return self._invalid('team not found')
 
         results = self._sector_result(team)
         results['campaigns'] = self._campaign_breakdowns(team)
-        self._fill_date_ranges()
         return self._success(results)
 
 
@@ -340,10 +317,6 @@ class SectorTeamsOverviewView(BaseSectorMIView):
 
     def get(self, request):
 
-        response = self._handle_fin_year(request)
-        if response:
-            return response
-
         # cache wins to avoid many queries
         hvc_wins, non_hvc_wins = self._wins().hvc(fin_year=self.fin_year), self._wins().non_hvc(fin_year=self.fin_year)
         for win in hvc_wins:
@@ -369,7 +342,6 @@ class SectorTeamsOverviewView(BaseSectorMIView):
         )
 
         result = [self._sector_data(team) for team in sector_team_qs]
-        self._fill_date_ranges()
 
         return self._success(sorted(result, key=itemgetter('name')))
 


### PR DESCRIPTION
This changes base MI wins view to use the helper methods
of date_range_start and date_range_end to filter the queryset.

Now we have one places where this comes from we can parse the query
param date and return that instead if it is set, and default to start
and end of the financial if it is not set.

This commit also fixes a bunch of naive tests that relied on the
incorrect behaviour of not filtering the queryset by today as the end
date if the financial year was the current financial year