### PR TITLE
Handle when HVCs are missing in csv export

### DIFF
--- a/alice/tests/client.py
+++ b/alice/tests/client.py
@@ -55,12 +55,12 @@ class AliceAuthenticator(AuthBase):
     <Response [200]>
     """
 
-    def __init__(self, secret, header=SIG_KEY):
+    def __init__(self, secret, header='X-Signature'):
         super().__init__()
         self.secret = secret
         self.header = header
 
     def __call__(self, r):
-        sig = _generate_signature(self.secret, r.url, r.body or '')
+        sig = _generate_signature(self.secret, r.path_url, r.body or '')
         r.headers[self.header] = sig
         return r

--- a/wins/views/flat_csv.py
+++ b/wins/views/flat_csv.py
@@ -183,7 +183,13 @@ class CSVView(APIView):
                 value = win[field_name]
             # if it is a choicefield, do optimized lookup of the display value
             if model_field.choices and value:
-                value = self._choices_dict(model_field.choices)[value]
+                try:
+                    value = self._choices_dict(model_field.choices)[value]
+                except KeyError as e:
+                    if model_field.attname == 'hvc':
+                        value = value
+                    else:
+                        raise e
             else:
                 comma_fields = [
                     'total_expected_export_value',


### PR DESCRIPTION
in staging and dev, the hvc choice field is empty and causes the csv
export to fail. this just returns the hvc code if that's the case