### PR TITLE
Make Docker use gunicorn instead of runserver

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,4 +2,4 @@
 cd /app
 python manage.py migrate --noinput
 python manage.py create_missing_hvcs
-python manage.py runserver 0.0.0.0:8000
+gunicorn -c gunicorn/conf.py data.wsgi --log-file - --access-logfile - --workers=$(nproc --all) --bind=0.0.0.0


### PR DESCRIPTION
This changes the default runner from the django built in `./manage.py
runserver` to use gunicorn instead. It'll be faster too