### PR TITLE
FDI: Verified % met should be against target

### DIFF
--- a/fdi/views.py
+++ b/fdi/views.py
@@ -101,7 +101,10 @@ class FDIOverview(BaseFDIView):
                 },
                 "pending": pending
             },
-            "verified_met_percent": two_digit_float((total / (total + pending['count'])) * 100)
+            "verified_met_percent": min(
+                two_digit_float((total / fdi_target.total) * 100) if fdi_target.total else 0,
+                100
+            )
         }
 
 

--- a/fdi/views.py
+++ b/fdi/views.py
@@ -101,10 +101,10 @@ class FDIOverview(BaseFDIView):
                 },
                 "pending": pending
             },
-            "verified_met_percent": min(
-                two_digit_float((total / fdi_target.total) * 100) if fdi_target.total else 0,
-                100
-            )
+            "verified_met_percent": two_digit_float(
+                (total / fdi_target.total) * 100
+            ) if fdi_target.total else 0.0
+
         }
 
 


### PR DESCRIPTION
Change json response from api to return verified % met as a ratio
against the target instead of total verified + total pending