### PR TITLE
Saml Middleware fix for Oauth users

### DIFF
--- a/sso/middleware/saml2.py
+++ b/sso/middleware/saml2.py
@@ -26,9 +26,11 @@ class SSOAuthenticationMiddleware(object):
         return adfsuser and adfsuser.is_authenticated()
 
     def process_request(self, request):
-        request.sso_authenticated = self.authenticated(request)
-        request.mi_permission = False
-        if request.sso_authenticated:
-            request.adfs_attributes = get_user_attributes(request)
-            request.mi_permission = has_MI_permission(request.adfs_attributes)
+        request.mi_permission = request.session.get('_source', None) == 'oauth2'
+        if not request.mi_permission:
+            request.sso_authenticated = self.authenticated(request)
+            request.mi_permission = False
+            if request.sso_authenticated:
+                request.adfs_attributes = get_user_attributes(request)
+                request.mi_permission = has_MI_permission(request.adfs_attributes)
         return None

--- a/sso/views/oauth2.py
+++ b/sso/views/oauth2.py
@@ -58,6 +58,9 @@ def callback(request):
             login(request, new_user,
                   backend=settings.AUTHENTICATION_BACKENDS[0])
             login(request, new_user)
+
+        request.session['_source'] = 'oauth2'
+        request.session.save()
         return HttpResponse('success')
     else:
         return HttpResponseForbidden()


### PR DESCRIPTION
Our SAML2 middleware was crashing if the user came from a  `oauth2`
login so we track this and treat those types of users differently when
checking `has_MI_permission`