### PR TITLE
Add option to enable http logging

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -21,3 +21,13 @@ def group_by_key(l: List[MutableMapping], key: str, flatten: bool = False) -> Mu
     for group, vals in itertools.groupby(l, key=key_getter):
         groups[group] = [filter_key(data, key) for data in vals]
     return {k: v[0] if flatten else v for k, v in groups.items()}
+
+
+def enable_http_logging():
+    import logging
+    import http.client as client
+    client.HTTPConnection.debuglevel = 1
+    logging.getLogger().setLevel(logging.DEBUG)
+    requests_log = logging.getLogger("requests.packages.urllib3")
+    requests_log.setLevel(logging.DEBUG)
+    requests_log.propagate = True

--- a/data/settings.py
+++ b/data/settings.py
@@ -9,6 +9,8 @@ import saml2.saml
 import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+from core.utils import enable_http_logging
+
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(PROJECT_ROOT)
 
@@ -383,6 +385,9 @@ else:
 # only show critical log message when running tests
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
     logging.disable(logging.CRITICAL)
+
+if os.getenv('ENABLE_HTTP_LOGGING', False):
+    enable_http_logging()
 
 
 # django countries only uses ISO countries. Wikipedia says, "XK is a


### PR DESCRIPTION
This is required so we can toggle it on to debug errors with ABC login
flows on production