### PR TITLE
FDI: add value=good/standard/high to wintable

### DIFF
--- a/fdi/serializers.py
+++ b/fdi/serializers.py
@@ -4,6 +4,20 @@ from fdi.models import Investments
 
 class InvestmentsSerializer(serializers.ModelSerializer):
 
+    value = serializers.SerializerMethodField('get_investment_value')
+
+    def get_investment_value(self, obj):
+        val = getattr(obj, 'value')
+        if val:
+            return val
+
+        if obj.approved_high_value:
+            return 'high'
+        elif obj.approved_good_value:
+            return 'good'
+        else:
+            return 'standard'
+
     class Meta:
         model = Investments
         fields = '__all__'

--- a/fdi/views.py
+++ b/fdi/views.py
@@ -313,7 +313,7 @@ class FDISectorTeamWinTable(FDIBaseSectorTeamView):
             target=Coalesce(Sum('hvc_target'), 0))['target']
         non_hvc_target = self.get_targets().aggregate(
             target=Coalesce(Sum('non_hvc_target'), 0))['target']
-        investments = InvestmentsSerializer(self.get_queryset(), many=True)
+        investments = InvestmentsSerializer(self.get_queryset().annotate(**ANNOTATIONS), many=True)
 
         return {
             "name": self.team.name,


### PR DESCRIPTION
this adds the value of an investment to the sector win table view, which
is required for the frontend designs

example output:
```json
			{
				"id": 15048,
				"value": "standard",
				"project_code": "P-1234",
				"stage": "Won",
				"number_new_jobs": 1,
				"number_safeguarded_jobs": 1,
				"approved_high_value": false,
				"approved_good_value": false,
				"date_won": "1901-01-01",
				"client_relationship_manager": "unknown",
				"client_relationship_manager_team": null,
				"company_name": "fake company",
				"company_reference": "1234",
				"investment_value": 1,
				"foreign_equity_investment": 1,
				"legacy": true,
				"sector": {
					"id": "ad22c9d2-5f95-e211-a939-e4115bead28a",
					"name": "Textiles, Interior Textiles and Carpets",
					"disabled_on": null
				},
				"uk_region": {
					"id": "874cd12a-6095-e211-a939-e4115bead28a",
					"name": "London",
					"disabled_on": null
				},
				"company_country": {
					"id": "84756b9a-5d95-e211-a939-e4115bead28a",
					"name": "Italy",
					"disabled_on": null,
					"iso_code": "IT"
				}
			},
```