### PR TITLE
Add @decorator for exempting views from Alice

### DIFF
--- a/alice/middleware.py
+++ b/alice/middleware.py
@@ -1,14 +1,31 @@
+from functools import wraps
 from hashlib import sha256
 
 from django.conf import settings
 from django.http import HttpResponseBadRequest
 from django.utils.crypto import constant_time_compare
+from django.utils.decorators import available_attrs
+
+
+def alice_exempt(view_func):
+    """
+    Marks a view function as being exempt from the alice view protection.
+    """
+    # We could just do view_func.alice_exempt = True, but decorators
+    # are nicer if they don't have side-effects, so we return a new
+    # function.
+    def wrapped_view(*args, **kwargs):
+        return view_func(*args, **kwargs)
+    wrapped_view.alice_exempt = True
+    return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
 
 
 class SignatureRejectionMiddleware(object):
     """ Rejects requests that are not signed by a known server """
 
-    def process_request(self, request):
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if getattr(view_func, 'alice_exempt', False):
+            return None
         if not self._test_signature(request):
             if settings.DEBUG and settings.API_DEBUG:
                 pass

--- a/csvfiles/views.py
+++ b/csvfiles/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.postgres.fields.jsonb import KeyTextTransform
 from django.db import models
 from django.db.models import Func, F, Max
+from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.utils.functional import cached_property
 from django.views.generic import TemplateView
@@ -23,6 +24,7 @@ from alice.authenticators import (
     IsMIUser,
     IsDataTeamServer
 )
+from alice.middleware import alice_exempt
 
 from csvfiles.constants import FILE_TYPES
 from csvfiles.models import File as CSVFile, File
@@ -412,6 +414,7 @@ class AllCSVFilesView(CSVBaseView):
         return Response(results, status=status.HTTP_200_OK)
 
 
+@method_decorator(alice_exempt, name='dispatch')
 class PingdomCustomCheckView(TemplateView):
     """
     A view which will respond with a NOT OK status if


### PR DESCRIPTION
This allows views to opt out of alice signature verification, this is
exactly the same way that csrf_exempt works from Django.

This also updates the Pingdom view so that it opts out of alice