### PR TITLE
Fix 500 error in hvc_groups

### DIFF
--- a/mi/views/sector_views.py
+++ b/mi/views/sector_views.py
@@ -85,8 +85,12 @@ class BaseSectorMIView(BaseWinMIView):
 
     def _get_group_wins(self, group):
         """ HVC wins of the HVC Group, for given `FinancialYear` """
+        campaigns_for_year = self._get_group_campaigns_for_year(group)
+        if not campaigns_for_year:
+            return self._hvc_wins().none()
         group_hvcs = [hvc[:4]
-                      for hvc in self._get_group_campaigns_for_year(group)]
+                      for hvc in campaigns_for_year]
+
         filter = reduce(
             operator.or_, [Q(hvc__startswith=hvc) for hvc in group_hvcs])
         return self._hvc_wins().filter(filter)


### PR DESCRIPTION
there is a 500 error when calling API for a HVC_group that doesn't have
any campaigns in the financial year specified. This checks for that
condition and returns an empty queryset instead