### PR TITLE
Allow any top_non_hvcs to return full results

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -77,7 +77,7 @@ class BaseMIView(APIView):
     def _invalid(self, msg):
         raise ParseError({'error': msg})
 
-    def _success(self, results):
+    def _success(self, results, **extra):
         if self.fin_year is not None:
             response = {
                 "timestamp": now(),
@@ -85,7 +85,8 @@ class BaseMIView(APIView):
                     "id": self.fin_year.id,
                     "description": self.fin_year.description,
                 },
-                "results": results
+                "results": results,
+                **extra
             }
 
             if self.date_range is not None:

--- a/mi/views/country_views.py
+++ b/mi/views/country_views.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django_countries.fields import Country as DjangoCountry
 
 from mi.models import Country
-from mi.views.base_view import BaseWinMIView, BaseExportMIView
+from mi.views.base_view import BaseWinMIView, BaseExportMIView, TopNonHvcMixin
 from mi.utils import sort_campaigns_by
 
 
@@ -129,12 +129,15 @@ class CountryCampaignsView(BaseCountriesMIView):
         return self._success(results)
 
 
-class CountryTopNonHvcWinsView(BaseCountriesMIView):
+class CountryTopNonHvcWinsView(BaseCountriesMIView, TopNonHvcMixin):
 
-    def get(self, request, country_code):
-        non_hvc_wins_qs = self._get_non_hvc_wins(self.country)
-        results = self._top_non_hvc(non_hvc_wins_qs)
-        return self._success(results)
+    entity_name = 'country'
+    entity_id_kwarg = 'country_code'
+
+    def __init__(self, **kwargs):
+        self.entity_getter_fn = lambda x: self.country
+        self.non_hvc_qs_getter_fn = self._get_non_hvc_wins
+        super().__init__(**kwargs)
 
 
 class CountryWinTableView(BaseCountriesMIView):

--- a/mi/views/region_views.py
+++ b/mi/views/region_views.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from mi.models import OverseasRegion, OverseasRegionGroup
 from mi.serializers import OverseasRegionGroupSerializer
 from mi.utils import sort_campaigns_by
-from mi.views.base_view import BaseWinMIView, BaseExportMIView
+from mi.views.base_view import BaseWinMIView, BaseExportMIView, TopNonHvcMixin
 
 
 class BaseOverseasRegionGroupMIView(BaseExportMIView):
@@ -178,17 +178,15 @@ class OverseasRegionCampaignsView(BaseOverseasRegionsMIView):
         return self._success(results)
 
 
-class OverseasRegionsTopNonHvcWinsView(BaseOverseasRegionsMIView):
+class OverseasRegionsTopNonHvcWinsView(BaseOverseasRegionsMIView, TopNonHvcMixin):
     """ Top n HVCs with win-breakdown for given Overseas Region"""
 
-    def get(self, request, region_id):
-        region = self._get_region(region_id)
-        if not region:
-            return self._invalid('region not found')
+    entity_name = 'region'
 
-        non_hvc_wins_qs = self._get_region_non_hvc_wins(region)
-        results = self._top_non_hvc(non_hvc_wins_qs)
-        return self._success(results)
+    def __init__(self, **kwargs):
+        self.entity_getter_fn = self._get_region
+        self.non_hvc_qs_getter_fn = self._get_region_non_hvc_wins
+        super(OverseasRegionsTopNonHvcWinsView, self).__init__(**kwargs)
 
 
 class OverseasRegionOverviewView(BaseOverseasRegionsMIView):

--- a/mi/views/sector_views.py
+++ b/mi/views/sector_views.py
@@ -12,7 +12,7 @@ from mi.models import (
     Target,
 )
 from mi.utils import sort_campaigns_by
-from mi.views.base_view import BaseWinMIView
+from mi.views.base_view import BaseWinMIView, TopNonHvcMixin
 
 
 def get_campaigns_from_group(g: HVCGroup, **kwargs):
@@ -136,16 +136,15 @@ class BaseSectorMIView(BaseWinMIView):
         }
 
 
-class TopNonHvcSectorCountryWinsView(BaseSectorMIView):
+class TopNonHvcSectorCountryWinsView(BaseSectorMIView, TopNonHvcMixin):
     """ Sector Team non-HVC Win data broken down by country """
 
-    def get(self, request, team_id):
-        team = self._get_team(team_id)
-        if not team:
-            return self._invalid('team not found')
-        non_hvc_wins_qs = self._get_non_hvc_wins(team)
-        results = self._top_non_hvc(non_hvc_wins_qs)
-        return self._success(results)
+    entity_name = 'team'
+
+    def __init__(self, **kwargs):
+        self.entity_getter_fn = self._get_team
+        self.non_hvc_qs_getter_fn = self._get_non_hvc_wins
+        super().__init__(**kwargs)
 
 
 class SectorTeamsListView(BaseSectorMIView):

--- a/mi/views/team_type_views.py
+++ b/mi/views/team_type_views.py
@@ -174,8 +174,14 @@ class TeamTypeWinTableView(BaseTeamTypeMIView):
 
 class TeamTypeNonHvcWinsView(BaseTeamTypeMIView):
 
+    def get(self, request, *args, **kwargs):
+        results, count = self._result()
+        return self._success(results, count=count)
+
     def _result(self):
-        return self._top_non_hvc(self._non_hvc_wins())
+        records_to_retrieve = None if self.request.GET.get('all') else 5
+        non_hvc_wins_qs = self._non_hvc_wins()
+        return self._top_non_hvc(non_hvc_wins_qs, records_to_retrieve=records_to_retrieve), non_hvc_wins_qs.count()
 
 
 class TeamTypeMonthsView(BaseTeamTypeMIView):


### PR DESCRIPTION
this allows any top_non_hvcs endpoint to return all results if it is
called with a ?all=true (any truthy value) get parameter