### PR TITLE
Fix top non hvc count bug

### DIFF
--- a/fixturedb/factories/win.py
+++ b/fixturedb/factories/win.py
@@ -47,7 +47,6 @@ def create_win_factory(user, sector_choices=None, default_date=None, default_tea
                 sector=sector_id,
                 date=win_date,
             )
-        win.save()
 
         if country is not None:
             win.country = country

--- a/mi/views/base_view.py
+++ b/mi/views/base_view.py
@@ -638,6 +638,7 @@ class BaseWinMIView(BaseExportMIView):
             total_wins=Count('id')
         ).order_by('-total_value')
 
+        total_count = len(non_hvc_wins)
         if records_to_retrieve:
             non_hvc_wins = non_hvc_wins[:records_to_retrieve]
 
@@ -658,7 +659,7 @@ class BaseWinMIView(BaseExportMIView):
                     percentage((w.get('total_value', 0) / w.get('total_wins', 0)), top_value) or 0
                 ),
             })
-        return data
+        return data, total_count
 
     def _win_table_wins(self, hvc_wins, non_hvc_wins=None):
         all_hvcs = {"{}{}".format(x["campaign_id"], x["financial_year"]): x["name"]
@@ -772,5 +773,5 @@ class TopNonHvcMixin:
 
         records_to_retrieve = None if self.request.GET.get('all') else 5
 
-        results = self._top_non_hvc(non_hvc_wins_qs, records_to_retrieve=records_to_retrieve)
-        return self._success(results, count=non_hvc_wins_qs.count())
+        results, count = self._top_non_hvc(non_hvc_wins_qs, records_to_retrieve=records_to_retrieve)
+        return self._success(results, count=count)

--- a/mi/views/team_type_views.py
+++ b/mi/views/team_type_views.py
@@ -181,7 +181,7 @@ class TeamTypeNonHvcWinsView(BaseTeamTypeMIView):
     def _result(self):
         records_to_retrieve = None if self.request.GET.get('all') else 5
         non_hvc_wins_qs = self._non_hvc_wins()
-        return self._top_non_hvc(non_hvc_wins_qs, records_to_retrieve=records_to_retrieve), non_hvc_wins_qs.count()
+        return self._top_non_hvc(non_hvc_wins_qs, records_to_retrieve=records_to_retrieve)
 
 
 class TeamTypeMonthsView(BaseTeamTypeMIView):


### PR DESCRIPTION
This fixes a bug with the top_non_hvc endpoints where previously they
were reporting a count much bigger than the total number of entries in
the result list.

This was because the result set was an aggregation of of individual
wins. The count was counting the individual wins that made up the
aggregation.