### PR TITLE
missing declaration for kantar

### DIFF
--- a/csvfiles/views.py
+++ b/csvfiles/views.py
@@ -430,6 +430,7 @@ class AllCSVFilesView(CSVBaseView):
             ]
 
         if kantar_monthly_files:
+            results['kantar'] = {}
             results['kantar']['months'] = [
                 {
                     'id': x.id,


### PR DESCRIPTION
fixing missing declaration for kantar within all_files.
results['kantar'] = {}