### PR TITLE
Update psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-filter==1.1.0
 djangorestframework==3.7.7
 factory-boy==2.10.0
 gunicorn==19.7.1
-psycopg2==2.7.3.2
+psycopg2-binary==2.7.4
 python-dateutil==2.6.1
 whitenoise==3.3.1
 requests==2.18.4


### PR DESCRIPTION
This is because psycopg2 will stop defaulting to a binary install soon.