### PR TITLE
Docker Gunicorn Logging

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,14 @@
 #!/bin/bash -xe
+set -euo pipefail
+IFS=$'\n\t'
+
 cd /app
+
+echo "Apply database migrations"
 python manage.py migrate --noinput
+
+echo "Creating HVCs"
 python manage.py create_missing_hvcs
-gunicorn -c gunicorn/conf.py data.wsgi --log-file - --access-logfile - --workers=$(nproc --all) --bind=0.0.0.0
+
+echo "Starting Gunicorn"
+gunicorn -c gunicorn/conf.py data.wsgi --log-file - --access-logfile - --workers=$(nproc --all) --bind=0.0.0.0 --timeout=55 --log-level=debug --capture-output


### PR DESCRIPTION
Increase loglevel of export-wins-data backend when running in docker. It only
runs inside docker for front-end tests so this is a safe change to make.