### PR TITLE
Add support for recording historical data

### DIFF
--- a/data/settings.py
+++ b/data/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     # misc 3rd party
     "django_extensions",
     "raven.contrib.django.raven_compat",
+    "trackstats",
 
     # local apps
     "core.apps.CoreConfig",

--- a/fdi/management/commands/trackstats_fdi.py
+++ b/fdi/management/commands/trackstats_fdi.py
@@ -1,0 +1,66 @@
+from django.core.management import BaseCommand
+from trackstats.models import StatisticByDateAndObject, Metric, Period
+
+from fdi.models import Investments, FinancialYear
+
+
+class Command(BaseCommand):
+    """
+    called like this:
+    ./manage.py trackstats_fdi
+
+    Freezes the stats like number of wins into the database using the `trackstats`
+    """
+
+    help = 'Freeze stats for FDI'
+
+    def handle(self, *args, **options):
+
+        fy = FinancialYear.objects.get(pk=FinancialYear.current_fy())
+        qs = Investments.objects.involved().for_year(fy)
+        total_count = qs.count()
+
+        # record total number of investments
+        rec = StatisticByDateAndObject.objects.record(
+            metric=Metric.objects.INVESTMENT_COUNT,
+            period=Period.LIFETIME,
+            object=fy,
+            value=total_count
+        )
+        print(rec)
+
+        won_count = qs.won().count()
+        rec = StatisticByDateAndObject.objects.record(
+            metric=Metric.objects.INVESTMENT_WON_COUNT,
+            period=Period.LIFETIME,
+            object=fy,
+            value=won_count
+        )
+        print(rec)
+
+        verify_win_count = qs.verified().count()
+        rec = StatisticByDateAndObject.objects.record(
+            metric=Metric.objects.INVESTMENT_VERIFY_WIN_COUNT,
+            period=Period.LIFETIME,
+            object=fy,
+            value=verify_win_count
+        )
+        print(rec)
+
+        active_count = qs.active().count()
+        rec = StatisticByDateAndObject.objects.record(
+            metric=Metric.objects.INVESTMENT_ACTIVE_COUNT,
+            period=Period.LIFETIME,
+            object=fy,
+            value=active_count
+        )
+        print(rec)
+
+        pipeline_count = qs.pipeline().count()
+        rec = StatisticByDateAndObject.objects.record(
+            metric=Metric.objects.INVESTMENT_PIPELINE_COUNT,
+            period=Period.LIFETIME,
+            object=fy,
+            value=pipeline_count
+        )
+        print(rec)

--- a/fdi/models/__init__.py
+++ b/fdi/models/__init__.py
@@ -1,3 +1,4 @@
 from .metadata import *
 from .importer import *
 from .live import *
+from .domains import *

--- a/fdi/models/domains.py
+++ b/fdi/models/domains.py
@@ -1,0 +1,34 @@
+from trackstats.models import Domain, Metric
+
+# Domains
+Domain.objects.INVESTMENT = Domain.objects.register(
+    ref='investment',
+    name='investment'
+)
+
+# Metrics, these are associated with a domain
+
+Metric.objects.INVESTMENT_COUNT = Metric.objects.register(
+    domain=Domain.objects.INVESTMENT,
+    ref='investment_count',
+    name='Number of investments in the system')
+
+Metric.objects.INVESTMENT_WON_COUNT = Metric.objects.register(
+    domain=Domain.objects.INVESTMENT,
+    ref='investment_won_count',
+    name='Number of investments in the system at stage won')
+
+Metric.objects.INVESTMENT_VERIFY_WIN_COUNT = Metric.objects.register(
+    domain=Domain.objects.INVESTMENT,
+    ref='investment_verify_win_count',
+    name='Number of investments in the system at stage verify win')
+
+Metric.objects.INVESTMENT_ACTIVE_COUNT = Metric.objects.register(
+    domain=Domain.objects.INVESTMENT,
+    ref='investment_active_count',
+    name='Number of investments in the system at stage active')
+
+Metric.objects.INVESTMENT_PIPELINE_COUNT = Metric.objects.register(
+    domain=Domain.objects.INVESTMENT,
+    ref='investment_pipeline_count',
+    name='Number of investments in the system not at stage verify win or win')

--- a/fdi/models/live.py
+++ b/fdi/models/live.py
@@ -1,5 +1,7 @@
+from datetime import timedelta
+
 from django.db import models
-from django.db.models import Sum, Value
+from django.db.models import Sum, Value, Q
 from django.db.models.functions import Coalesce
 
 from fdi.models.metadata import (
@@ -27,6 +29,9 @@ class InvestmentsQuerySet(models.QuerySet):
     def verified(self):
         return self.filter(stage='verify win')
 
+    def active(self):
+        return self.filter(stage='active')
+
     def pipeline(self):
         return self.exclude(stage__in=['won', 'verify win'])
 
@@ -35,6 +40,15 @@ class InvestmentsQuerySet(models.QuerySet):
 
     def won_verify_and_active(self):
         return self.filter(stage__in=['won', 'verify win', 'active'])
+
+    def for_year(self, year: FinancialYear):
+        # range is not inclusive
+        return self.filter(date_won__range=(year.start, year.end + timedelta(days=1)))
+
+    def involved(self):
+        return self.filter(
+            ~Q(level_of_involvement__name='No Involvement'), investment_type__name='FDI'
+        )
 
 
 class SectorTeam(models.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ URLObject==2.4.3
 requests-oauthlib==0.8.0
 zipstream==1.1.4
 cytoolz==0.9.0.1
+django-trackstats==0.5.0
 
 # Tests
 Faker==0.8.11


### PR DESCRIPTION
using django library called django `trackstats`.

This allows us to store metrics/stats in a generic way per date