### PR TITLE
Add sqlparse to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-extended-choices==1.3
 openpyxl==2.5.1
 URLObject==2.4.3
 requests-oauthlib==0.8.0
+sqlparse==0.2.4
 zipstream==1.1.4
 cytoolz==0.9.0.1
 django-trackstats==0.5.0


### PR DESCRIPTION
Include sqlparse - one of the migrations in csvfile[1] was causing the error:

"django.core.exceptions.ImproperlyConfigured: sqlparse is required if you don't split your SQL statements manually."


[1] csvfiles/migrations/0003_auto_20171108_1308.py