### PR TITLE
(feat) Activity stream endpoint for pen-testing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,10 @@ export DEBUG=True
 export API_DEBUG=True
 export DATABASE_URL='postgres://postgres@127.0.0.1:5432/export-wins-data'
 
+export ACTIVITY_STREAM_IP_WHITELIST='1.2.3.4'
+export ACTIVITY_STREAM_ACCESS_KEY_ID='some-id'
+export ACTIVITY_STREAM_SECRET_ACCESS_KEY='some-secret'
+
 #read only
 export AWS_KEY_CSV_READ_ONLY_ACCESS=aws-read-key
 export AWS_SECRET_CSV_READ_ONLY_ACCESS=aws-read-secret

--- a/activity_stream/apps.py
+++ b/activity_stream/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ActivityStreamConfig(AppConfig):
+    name = 'activity_stream'

--- a/activity_stream/tests/test_views.py
+++ b/activity_stream/tests/test_views.py
@@ -1,0 +1,264 @@
+import datetime
+
+import mohawk
+import pytest
+from django.conf import settings
+from django.core.cache import CacheHandler
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def local_memory_cache(monkeypatch):
+    monkeypatch.setitem(
+        settings.CACHES,
+        'default',
+        {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'},
+    )
+    monkeypatch.setattr('django.core.cache.caches', CacheHandler())
+
+
+def _url():
+    return 'http://testserver' + reverse('activity-stream')
+
+
+def _url_incorrect_domain():
+    return 'http://incorrect' + reverse('activity-stream')
+
+
+def _url_incorrect_path():
+    return 'http://testserver' + reverse('activity-stream') + 'incorrect/'
+
+
+def _auth_sender(key_id='some-id', secret_key='some-secret', url=_url,
+                 method='GET', content='', content_type=''):
+    credentials = {
+        'id': key_id,
+        'key': secret_key,
+        'algorithm': 'sha256',
+    }
+    return mohawk.Sender(
+        credentials,
+        url(),
+        method,
+        content=content,
+        content_type=content_type,
+    )
+
+
+@pytest.mark.parametrize(
+    'get_kwargs,expected_json',
+    (
+        (
+            # If no X-Forwarded-For header
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the first IP in X-Forwarded-For header isn't in the whitelist
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='9.9.9.9',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header isn't passed
+            dict(
+                content_type='',
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Authentication credentials were not provided.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect ID
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    key_id='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect secret
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    secret_key='incorrect'
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect domain
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    url=_url_incorrect_domain,
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect path
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    url=_url_incorrect_path,
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect method
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    method='POST',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect
+            # content-type
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    content_type='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from incorrect content
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    content='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+    ),
+)
+@pytest.mark.django_db
+def test_401_returned(api_client, get_kwargs, expected_json):
+    """If the request isn't properly Hawk-authenticated, then a 401 is
+    returned
+    """
+    response = api_client.get(
+        _url(),
+        **get_kwargs,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == expected_json
+
+
+@pytest.mark.django_db
+def test_if_61_seconds_in_past_401_returned(api_client):
+    """If the Authorization header is generated 61 seconds in the past, then a
+    401 is returned
+    """
+    past = datetime.datetime.now() - datetime.timedelta(seconds=61)
+    with freeze_time(past):
+        auth = _auth_sender().request_header
+    response = api_client.get(
+        reverse('activity-stream'),
+        content_type='',
+        HTTP_AUTHORIZATION=auth,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    error = {'detail': 'Incorrect authentication credentials.'}
+    assert response.json() == error
+
+
+@pytest.mark.usefixtures('local_memory_cache')
+@pytest.mark.django_db
+def test_if_authentication_reused_401_returned(api_client):
+    """If the Authorization header is reused, then a 401 is returned"""
+    auth = _auth_sender().request_header
+
+    response_1 = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=auth,
+        HTTP_X_FORWARDED_FOR='1.2.3.4',
+    )
+    assert response_1.status_code == status.HTTP_200_OK
+
+    response_2 = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=auth,
+        HTTP_X_FORWARDED_FOR='1.2.3.4',
+    )
+    assert response_2.status_code == status.HTTP_401_UNAUTHORIZED
+    error = {'detail': 'Incorrect authentication credentials.'}
+    assert response_2.json() == error
+
+
+@pytest.mark.django_db
+def test_empty_object_returned_with_authentication(api_client):
+    """If the Authorization and X-Forwarded-For headers are correct, then
+    the correct, and authentic, data is returned
+    """
+    sender = _auth_sender()
+    response = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    content = {'secret': 'content-for-pen-test'}
+    assert response.json() == content
+
+    # Just asserting that accept_response doesn't raise is a bit weak,
+    # so we also assert that it raises if the header, content, or
+    # content_type are incorrect
+    sender.accept_response(
+        response_header=response['Server-Authorization'],
+        content=response.content,
+        content_type=response['Content-Type'],
+    )
+    with pytest.raises(mohawk.exc.MacMismatch):
+        sender.accept_response(
+            response_header=response['Server-Authorization'] + 'incorrect',
+            content=response.content,
+            content_type=response['Content-Type'],
+        )
+    with pytest.raises(mohawk.exc.MisComputedContentHash):
+        sender.accept_response(
+            response_header=response['Server-Authorization'],
+            content='incorrect',
+            content_type=response['Content-Type'],
+        )
+    with pytest.raises(mohawk.exc.MisComputedContentHash):
+        sender.accept_response(
+            response_header=response['Server-Authorization'],
+            content=response.content,
+            content_type='incorrect',
+        )

--- a/activity_stream/views.py
+++ b/activity_stream/views.py
@@ -1,0 +1,142 @@
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+from django.utils.crypto import constant_time_compare
+from django.utils.decorators import (
+    decorator_from_middleware,
+    method_decorator,
+)
+from mohawk import Receiver
+from mohawk.exc import HawkFail
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from alice.middleware import alice_exempt
+
+logger = logging.getLogger(__name__)
+
+NO_CREDENTIALS_MESSAGE = 'Authentication credentials were not provided.'
+INCORRECT_CREDENTIALS_MESSAGE = 'Incorrect authentication credentials.'
+
+
+def _lookup_credentials(access_key_id):
+    """Raises a HawkFail if the passed ID is not equal to
+    settings.ACTIVITY_STREAM_ACCESS_KEY_ID
+    """
+    if not constant_time_compare(access_key_id,
+                                 settings.ACTIVITY_STREAM_ACCESS_KEY_ID):
+        raise HawkFail(f'No Hawk ID of {access_key_id}')
+
+    return {
+        'id': settings.ACTIVITY_STREAM_ACCESS_KEY_ID,
+        'key': settings.ACTIVITY_STREAM_SECRET_ACCESS_KEY,
+        'algorithm': 'sha256',
+    }
+
+
+def _seen_nonce(access_key_id, nonce, _):
+    """Returns if the passed access_key_id/nonce combination has been
+    used within settings.ACTIVITY_STREAM_NONCE_EXPIRY_SECONDS
+    """
+    cache_key = f'activity_stream:{access_key_id}:{nonce}'
+
+    # cache.add only adds key if it isn't present
+    seen_cache_key = not cache.add(
+        cache_key, True, timeout=settings.ACTIVITY_STREAM_NONCE_EXPIRY_SECONDS,
+    )
+
+    if seen_cache_key:
+        logger.warning(f'Already seen nonce {nonce}')
+
+    return seen_cache_key
+
+
+def _authorise(request):
+    """Raises a HawkFail if the passed request cannot be authenticated"""
+    return Receiver(
+        _lookup_credentials,
+        request.META['HTTP_AUTHORIZATION'],
+        request.build_absolute_uri(),
+        request.method,
+        content=request.body,
+        content_type=request.content_type,
+        seen_nonce=_seen_nonce,
+    )
+
+
+class _ActivityStreamAuthentication(BaseAuthentication):
+
+    def authenticate_header(self, request):
+        """This is returned as the WWW-Authenticate header when
+        AuthenticationFailed is raised. DRF also requires this
+        to send a 401 (as opposed to 403)
+        """
+        return 'Hawk'
+
+    def authenticate(self, request):
+        """Authenticates a request using two mechanisms:
+
+        1. The X-Forwarded-For-Header, compared against a whitelist
+        2. A Hawk signature in the Authorization header
+
+        If either of these suggest we cannot authenticate, AuthenticationFailed
+        is raised, as required in the DRF authentication flow
+        """
+        if 'HTTP_X_FORWARDED_FOR' not in request.META:
+            logger.warning(
+                'Failed authentication: no X-Forwarded-For header passed'
+            )
+            raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
+
+        x_forwarded_for = request.META['HTTP_X_FORWARDED_FOR']
+        remote_address = x_forwarded_for.split(',', maxsplit=1)[0].strip()
+
+        if remote_address not in settings.ACTIVITY_STREAM_IP_WHITELIST:
+            logger.warning(
+                'Failed authentication: the X-Forwarded-For header did not '
+                'start with an IP in the whitelist'
+            )
+            raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
+
+        if 'HTTP_AUTHORIZATION' not in request.META:
+            raise AuthenticationFailed(NO_CREDENTIALS_MESSAGE)
+
+        try:
+            hawk_receiver = _authorise(request)
+        except HawkFail as e:
+            logger.warning(f'Failed authentication {e}')
+            raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
+
+        return (None, hawk_receiver)
+
+
+class _ActivityStreamHawkResponseMiddleware:
+    """Adds the Server-Authorization header to the response, so the originator
+    of the request can authenticate the response
+    """
+
+    def process_response(self, viewset, response):
+        """Adds the Server-Authorization header to the response, so the originator
+        of the request can authenticate the response
+        """
+        response['Server-Authorization'] = viewset.request.auth.respond(
+            content=response.content,
+            content_type=response['Content-Type'],
+        )
+        return response
+
+
+@method_decorator(alice_exempt, name='dispatch')
+class ActivityStreamViewSet(ViewSet):
+    """List-only view set for the activity stream"""
+
+    authentication_classes = (_ActivityStreamAuthentication,)
+    permission_classes = ()
+
+    @decorator_from_middleware(_ActivityStreamHawkResponseMiddleware)
+    def list(self, request):
+        """A single page of activities"""
+        return Response({'secret': 'content-for-pen-test'})

--- a/data/settings.py
+++ b/data/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     "sso.apps.SsoConfig",
     "fixturedb.apps.FixtureDBConfig",
     "fdi.apps.InvestmentConfig",
+    "activity_stream.apps.ActivityStreamConfig",
     "csvfiles",
 
     # drf
@@ -328,3 +329,11 @@ COUNTRIES_OVERRIDE = {
     'FK': 'Falkland Islands',
     'CZ': 'Czech Republic',
 }
+
+# Activity Stream
+ACTIVITY_STREAM_IP_WHITELIST = os.getenv('ACTIVITY_STREAM_IP_WHITELIST', default='')
+# Defaults are not used so we don't accidentally expose the endpoint
+# with default credentials
+ACTIVITY_STREAM_ACCESS_KEY_ID = os.environ['ACTIVITY_STREAM_ACCESS_KEY_ID']
+ACTIVITY_STREAM_SECRET_ACCESS_KEY = os.environ['ACTIVITY_STREAM_SECRET_ACCESS_KEY']
+ACTIVITY_STREAM_NONCE_EXPIRY_SECONDS = 60

--- a/data/urls.py
+++ b/data/urls.py
@@ -9,6 +9,7 @@ import fdi.urls
 import mi.urls
 import sso.oauth2_urls
 
+from activity_stream.views import ActivityStreamViewSet
 from users.views import IsLoggedIn, LoginView, UserRetrieveViewSet, LogoutView
 from wins.views import (
     WinViewSet, BreakdownViewSet, AdvisorViewSet, ConfirmationViewSet,
@@ -75,6 +76,11 @@ urlpatterns = [
         UserRetrieveViewSet.as_view({'get': 'retrieve'}), name="user_profile"),
 
     url(r"^auth/logout/", LogoutView.as_view(), name="logout"),
+
+    url(
+        r'^activity-stream/$',
+        ActivityStreamViewSet.as_view({'get': 'list'}),
+        name='activity-stream'),
 
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-filter==1.1.0
 djangorestframework==3.7.7
 factory-boy==2.10.0
 gunicorn==19.8.1
+mohawk==0.3.4
 psycopg2-binary==2.7.5
 python-dateutil==2.7.0
 whitenoise==3.3.1


### PR DESCRIPTION
The is some duplication/similarity between this and endpoints in other
projects. The commonalities are _not_ factored out...

... Coupling them together slows independent developement of each. They are
already running different Python and Django versions, one Python project (the
Activity Stream itself) isn't using Django, and one service is Ruby (which
would be tricky to factor out!). The Activity Stream itself aready places a
(albeit/hopefully small!) burden on each project, and don't want this to be
made larger by requiring project developers to look and make changes in another
repository that potentially has to support multiple Python/Django versions...

... And it's not that much code. It is expected that there will be much more
project-specific code to query-for and generate the data. Or, there may be
other places that would be more useful to factor out. e.g. maybe a common
library for generating "activities" may be more useful. Or even some projects
may need different authentication mechanisms. This may be difficult if
factoring out small parts at an early stage.