### PR TITLE
Pin redis to 2.10.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,11 @@ requests-oauthlib==0.8.0
 zipstream==1.1.4
 cytoolz==0.9.0.1
 django-trackstats==0.5.0
+
+redis==2.10.6
+redis-py-cluster==1.3.6
 django-redis==4.9.0
-redis-py-cluster==1.3.4
+
 python-json-logger==0.1.5
 
 # Development utilities


### PR DESCRIPTION
The libs redis-py-cluster and django-redis caused redis 3 to be
installed because of their relaxed requirements.

This pins redis to version 2.10.6.

Note: at the moment redis-py-cluster==1.3.6 fixed the issue but
django-redis is still causing redis 3 to be installed unless it
comes after redis-py-cluster in the requirements file which is
not ideal.

Pinning redis explicitly seems a better solution for now.