### PR TITLE
DST-1259 Integrate `permitted_applications` in the user endpoint

### DIFF
--- a/data/urls.py
+++ b/data/urls.py
@@ -10,7 +10,7 @@ import mi.urls
 import sso.oauth2_urls
 
 from activity_stream.views import ActivityStreamViewSet
-from users.views import IsLoggedIn, LoginView, UserRetrieveViewSet, LogoutView
+from users.views import IsLoggedIn, LoginView, LoggedInUserRetrieveViewSet, LogoutView
 from wins.views import (
     WinViewSet, BreakdownViewSet, AdvisorViewSet, ConfirmationViewSet,
     LimitedWinViewSet, CSVView, DetailsWinViewSet, AddUserView,
@@ -73,7 +73,7 @@ urlpatterns = [
 
     url(r"^auth/is-logged-in/$", IsLoggedIn.as_view(), name="is-logged-in"),
     url(r"^user/me/$",
-        UserRetrieveViewSet.as_view({'get': 'retrieve'}), name="user_profile"),
+        LoggedInUserRetrieveViewSet.as_view({'get': 'retrieve'}), name="user_profile"),
 
     url(r"^auth/logout/", LogoutView.as_view(), name="logout"),
 

--- a/sso/views/oauth2.py
+++ b/sso/views/oauth2.py
@@ -5,6 +5,7 @@ This is not a typical oauth2 implementation, in order to keep saml2 as backup au
 for web-application-flow
 see http://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html
 """
+
 from django.conf import settings
 from django.contrib.auth import get_user_model, login
 from django.http import HttpResponseForbidden, HttpResponse, JsonResponse, HttpResponseBadRequest
@@ -55,6 +56,7 @@ def callback(request):
         user_model = get_user_model()
         name = ' '.join(filter(bool, [abc_data.get('first_name'), abc_data.get('last_name')]))[:128].strip()
         sso_user_id = abc_data.get('user_id')
+        permitted_applications = abc_data.get('permitted_applications', {})
         # 1. log them in if they already exist
         try:
             user = user_model.objects.get(email=abc_data['email'])
@@ -72,6 +74,7 @@ def callback(request):
                 name=name,
                 sso_user_id=sso_user_id,
             )
+
             # they won't ever need to login using user/pass
             new_user.set_unusable_password()
             new_user.save()
@@ -81,6 +84,7 @@ def callback(request):
 
         request.session['_source'] = 'oauth2'
         request.session['_abc_token'] = token
+        request.session['_abc_permitted_applications'] = permitted_applications
         request.session['_token_introspected_at'] = now().timestamp()
         request.session.save()
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -40,13 +40,18 @@ class LoggingAuthTokenSerializer(AuthTokenSerializer):
             raise e
 
 
-class UserSerializer(serializers.ModelSerializer):
+class LoggedInUserSerializer(serializers.ModelSerializer):
 
     name = SerializerMethodField()
+    permitted_applications = SerializerMethodField()
 
     def get_name(self, obj):
         return getattr(obj, 'name', obj.email)
 
+    def get_permitted_applications(self, obj):
+        request = self.context['request']
+        return request.session.get('_abc_permitted_applications', {})
+
     class Meta:
         model = User
-        fields = ('email', 'last_login', 'name')
+        fields = ('email', 'last_login', 'name', 'permitted_applications')

--- a/users/views.py
+++ b/users/views.py
@@ -14,7 +14,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from alice.authenticators import IsMIServer, IsMIUser
-from .serializers import LoggingAuthTokenSerializer, UserSerializer
+from .serializers import LoggingAuthTokenSerializer, LoggedInUserSerializer
 
 
 class LoginView(APIView):
@@ -70,9 +70,9 @@ class IsLoggedIn(APIView):
         return HttpResponse(json.dumps(bool(request.user.is_authenticated)))
 
 
-class UserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+class LoggedInUserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     permission_classes = (IsMIServer, IsMIUser)
-    serializer_class = UserSerializer
+    serializer_class = LoggedInUserSerializer
     http_method_names = ('get')
 
     def get_object(self):


### PR DESCRIPTION
Part of the global nav implementation. MI uses SSO differently, so there
is a need to have permitted_applications in the backend call to the MI
frontend, where this list is being queried in order to only show in the
nav the allowed links