### PR TITLE
Update wording of export experience category

### DIFF
--- a/wins/constants.py
+++ b/wins/constants.py
@@ -1325,7 +1325,7 @@ EXPERIENCE_CATEGORIES = Choices(
     ('NOPLAN', 3, "Has exported in the past twelve months but has not "
                   "won an export order proactively as a result of having an export plan"),
     ('NEW_MARKET', 7, "Is an exporter which did not receive or fulfil any export orders to this "
-                      "market between 1 April 2015 and 31 March 2018"),
+                      "market in the three financial years before this win"),
     ('GROWTH', 6, "Is an exporter that we are helping to maintain and grow its exports"),
     # Inactive
     ('SMALL', 4,

--- a/wins/models.py
+++ b/wins/models.py
@@ -427,8 +427,8 @@ class Win(SoftDeleteModel):
             constants.EXPERIENCE_CATEGORIES.GROWTH:
                 'You wanted to maintain and grow your exports',
             constants.EXPERIENCE_CATEGORIES.NEW_MARKET:
-                'Have not won or fulfilled any export orders to this country between 1 April 2015 '
-                'and 31 March 2018',
+                'Did not win or fulfil any export orders to this country in the three UK '
+                'financial years (1 April to 31 March) before this win',
         }
         return customer_map[self.export_experience]
 


### PR DESCRIPTION
This updates the wording of one of the export experience categories so that it works for wins in different financial years.

This is part of the preparation for the new financial year.