### PR TITLE
Company Matching API

### DIFF
--- a/data/settings.py
+++ b/data/settings.py
@@ -401,3 +401,7 @@ CACHES = {
         'KEY_PREFIX': 'export-wins-data',
     },
 }
+
+COMPANY_MATCHING_SERVICE_BASE_URL = os.getenv('COMPANY_MATCHING_SERVICE_BASE_URL', default=None)
+COMPANY_MATCHING_HAWK_ID = os.getenv('COMPANY_MATCHING_HAWK_ID', default=None)
+COMPANY_MATCHING_HAWK_KEY = os.getenv('COMPANY_MATCHING_HAWK_KEY', default=None)

--- a/data/settings_test.py
+++ b/data/settings_test.py
@@ -42,3 +42,7 @@ HAWK_RECEIVER_CREDENTIALS = {
         'scopes': (),
     },
 }
+
+COMPANY_MATCHING_SERVICE_BASE_URL = 'http://company.matching/'
+COMPANY_MATCHING_HAWK_ID = 'some-id'
+COMPANY_MATCHING_HAWK_KEY = 'some-secret'

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,5 @@ pytest==3.8.1
 pytest-django==3.4.4
 coverage-pth==0.0.2
 pytest-sugar==0.9.1
+requests-mock==1.7.0
+parameterized==0.7.1

--- a/wins/company_matching_utils.py
+++ b/wins/company_matching_utils.py
@@ -1,0 +1,157 @@
+import json
+from urllib.parse import urljoin
+
+from mohawk import Sender
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+import requests
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+
+
+class CompanyMatchingServiceException(Exception):
+    """
+    Base exception class for Company matching service related errors.
+    """
+
+
+class CompanyMatchingServiceHTTPError(Exception):
+    """
+    Base exception class for Company matching service related errors.
+    """
+
+
+class CompanyMatchingServiceTimeoutError(CompanyMatchingServiceException):
+    """
+    Exception for when a timeout was encountered when connecting to Company matching service.
+    """
+
+
+class CompanyMatchingServiceConnectionError(CompanyMatchingServiceException):
+    """
+    Exception for when an error was encountered when connecting to Company matching service.
+    """
+
+
+def _post(path, json_body):
+    """
+    Sends a HAWK authenticated post request to the company matching service
+    with a json body.
+    """
+    url = urljoin(settings.COMPANY_MATCHING_SERVICE_BASE_URL, path)
+    # Signs a request
+    sender = Sender(
+        {
+            'id': settings.COMPANY_MATCHING_HAWK_ID,
+            'key': settings.COMPANY_MATCHING_HAWK_KEY,
+            'algorithm': 'sha256'
+        },
+        url=url,
+        method='POST',
+        content_type='application/json',
+        content=json.dumps(json_body),
+    )
+    # Post JSON to the company matching service
+    response = requests.post(
+        url,
+        json=json_body,
+        headers={
+            'Authorization': sender.request_header,
+            'Content-Type': 'application/json',
+        }
+    )
+    response.raise_for_status()
+    if response.ok:
+        # Verify response from the company matching service
+        sender.accept_response(
+            response.headers['Server-Authorization'],
+            content=response.content,
+            content_type=response.headers['Content-Type'],
+        )
+    return response
+
+
+def _request_match_companies(json_body):
+    """
+    Queries the company matching service with the given json_body. E.g.:
+    {
+        "descriptions": [
+            {
+                "id": "1",
+                "companies_house_id": "0921309",
+                "duns_number": "d210"
+                "company_name":"apple",
+                "contact_email": "john@apple.com",
+                "cdms_ref": "782934",
+                "postcode": "SW129RP"
+            }
+        ]
+    }
+
+    Note that the ID field typically the company UUID that is returned by the api for data mapping.
+    ID and at least one of the following fields companies_house_id, duns_number, company_name,
+    contact_email, cdms_ref and postcode are required.
+    """
+    if not all([
+        settings.COMPANY_MATCHING_SERVICE_BASE_URL,
+        settings.COMPANY_MATCHING_HAWK_ID,
+        settings.COMPANY_MATCHING_HAWK_KEY,
+    ]):
+        raise ImproperlyConfigured('The all COMPANY_MATCHING_SERVICE_* setting must be set')
+
+    response = _post('api/v1/company/match/', json_body)
+    return response
+
+
+def _company_house_or_cdms_number(ref):
+    """Validate the data to return a company house or cdms number."""
+    if bool(ref):
+        if len(ref) == 8:
+            """
+            Attempt to convert the company house number to an int, we're not going to use the value
+            because we do not want to make any assumptions for the format we only care if all the chracters are
+            numbers and are 8 digits long. e.g if a number is 000123 the int will return 123.
+            """
+            try:
+                int(ref)
+                return {'companies_house_id': ref}
+            except ValueError:
+                pass
+        return {'cdms_ref': ref}
+    else:
+        return {}
+
+
+def _format_company_for_post(wins):
+    """Format the Company model to json for the POST body."""
+    return {
+        'descriptions': [
+            {
+                'id': str(win.pk),
+                'company_name': win.company_name,
+                'contact_email': win.customer_email_address,
+                **_company_house_or_cdms_number(win.cdms_reference),
+            } for win in wins
+        ],
+    }
+
+
+def update_match_ids(wins):
+    """
+    Get companies match from a Win queryset and updates the match_id fields from the company matching service.
+    Raises exception an requests.exceptions.HTTPError for status, timeout and a connection error.
+    """
+    try:
+        response = _request_match_companies(_format_company_for_post(wins))
+    except ConnectionError as exc:
+        error_message = 'Encountered an error connecting to Company matching service'
+        raise CompanyMatchingServiceConnectionError(error_message) from exc
+    except Timeout as exc:
+        error_message = 'Encountered a timeout interacting with Company matching service'
+        raise CompanyMatchingServiceTimeoutError(error_message) from exc
+    except HTTPError as exc:
+        error_message = (
+            'The Company matching service returned an error status: '
+            f'{exc.response.status_code}'
+        )
+        raise CompanyMatchingServiceHTTPError(error_message) from exc
+    return response

--- a/wins/tests/test_company_matching_utils.py
+++ b/wins/tests/test_company_matching_utils.py
@@ -1,0 +1,159 @@
+from django.conf import settings
+import requests_mock
+from parameterized import parameterized
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test.utils import override_settings
+from django.test import TestCase
+from requests.exceptions import (
+    ConnectionError,
+    ConnectTimeout,
+    ReadTimeout,
+    Timeout,
+)
+from rest_framework import status
+
+from wins.company_matching_utils import (
+    CompanyMatchingServiceConnectionError,
+    CompanyMatchingServiceHTTPError,
+    CompanyMatchingServiceTimeoutError,
+    update_match_ids,
+)
+from wins.factories import WinFactory
+from wins.models import Win
+from wins.tests.utils import HawkMockJSONResponse
+
+
+class TestCompanyMatchingApi(TestCase):
+    """
+    Tests Company matching API functionality including formating a Company Object
+    to JSON to post to the company matching service and error handling.
+    """
+
+    @requests_mock.Mocker(kw='requests_mock')
+    def test_model_to_match_payload(
+        self,
+        requests_mock,
+    ):
+        """
+        Test that the function maps the Company object to JSON correctly
+        also stripping out falsy values.
+        """
+        WinFactory(
+            id='00000000-0000-0000-0000-000000000000',
+            company_name='Name 1',
+            cdms_reference='00000000',
+            customer_email_address='test@example.com',
+        )
+        WinFactory(
+            id='00000000-0000-0000-0000-000000000001',
+            company_name='Name 2',
+            cdms_reference='cdms00000000',
+            customer_email_address='test@example.com',
+        )
+
+        dynamic_response = HawkMockJSONResponse(
+            api_id=settings.COMPANY_MATCHING_HAWK_ID,
+            api_key=settings.COMPANY_MATCHING_HAWK_KEY,
+        )
+        matcher = requests_mock.post(
+            '/api/v1/company/match/',
+            status_code=status.HTTP_200_OK,
+            text=dynamic_response,
+        )
+        update_match_ids(
+            Win.objects.filter(customer_email_address='test@example.com')
+        )
+        assert matcher.called_once
+        assert matcher.last_request.json() == {
+            'descriptions': [
+                {
+                    'id': '00000000-0000-0000-0000-000000000000',
+                    'company_name': 'Name 1',
+                    'contact_email': 'test@example.com',
+                    'companies_house_id': '00000000',
+                },
+                {
+                    'id': '00000000-0000-0000-0000-000000000001',
+                    'company_name': 'Name 2',
+                    'contact_email': 'test@example.com',
+                    'cdms_ref': 'cdms00000000',
+                },
+            ],
+        }
+
+    @override_settings(COMPANY_MATCHING_SERVICE_BASE_URL=None)
+    def test_missing_settings_error(self):
+        """
+        Test when environment variables are not set an exception is thrown.
+        """
+        WinFactory()
+        with self.assertRaises(ImproperlyConfigured):
+            update_match_ids(Win.objects.all())
+
+    @parameterized.expand(
+        [
+            (
+                ConnectionError,
+                CompanyMatchingServiceConnectionError,
+            ),
+            (
+                ConnectTimeout,
+                CompanyMatchingServiceConnectionError,
+            ),
+            (
+                Timeout,
+                CompanyMatchingServiceTimeoutError,
+            ),
+            (
+                ReadTimeout,
+                CompanyMatchingServiceTimeoutError,
+            ),
+        ],
+    )
+    @requests_mock.Mocker(kw='requests_mock')
+    def test_company_matching_service_request_error(
+        self,
+        request_exception,
+        expected_exception,
+        requests_mock,
+    ):
+        """
+        Test if there is an error connecting to company matching service
+        the expected exception was thrown.
+        """
+        requests_mock.post(
+            '/api/v1/company/match/',
+            exc=request_exception,
+        )
+        WinFactory()
+        with self.assertRaises(expected_exception):
+            update_match_ids(Win.objects.all())
+
+    @parameterized.expand(
+        [
+            (status.HTTP_400_BAD_REQUEST,),
+            (status.HTTP_401_UNAUTHORIZED,),
+            (status.HTTP_403_FORBIDDEN,),
+            (status.HTTP_404_NOT_FOUND,),
+            (status.HTTP_405_METHOD_NOT_ALLOWED,),
+            (status.HTTP_500_INTERNAL_SERVER_ERROR,),
+        ],
+    )
+    @requests_mock.Mocker(kw='requests_mock')
+    def test_company_matching_service_error(
+        self,
+        response_status,
+        requests_mock,
+    ):
+        """Test if the company matching service returns a status code that is not 200."""
+        requests_mock.post(
+            '/api/v1/company/match/',
+            status_code=response_status,
+        )
+        WinFactory()
+        with self.assertRaises(
+            CompanyMatchingServiceHTTPError,
+            msg=f'The Company matching service returned an error status: {response_status}',
+        ):
+            update_match_ids(Win.objects.all())

--- a/wins/tests/utils.py
+++ b/wins/tests/utils.py
@@ -1,0 +1,69 @@
+import json
+
+import mohawk
+
+
+class HawkMockJSONResponse:
+    """
+    Mock utility mocking server validation for POST content.
+    This is needed when mocking responses when using the APIClient and HawkAuth.
+
+    The default reponse is an empty JSON but can be overridden by passing in a
+    response argument into the constructor.
+
+    dynamic_reponse = HawkMockJSONResponse(
+        api_id='some-id',
+        api_key='some-key'
+        response={'content': 'Hello'}
+    )
+
+    requests_mock.post(
+        'some/api/',
+        status_code=status.HTTP_200_OK,
+        json=dynamic_reponse,
+    )
+    """
+
+    def __init__(
+        self,
+        api_id,
+        api_key,
+        algorithm='sha256',
+        content_type='application/json',
+        response=None,
+    ):
+        """
+        Initialise with a dict that can be serialized to json
+        this reponse body will be validated and returned in the mock reponse.
+        """
+        self.credentials = {
+            'id': api_id,
+            'key': api_key,
+            'algorithm': algorithm,
+        }
+        self._response = response
+        self.content_type = content_type
+        if self._response is None:
+            self._response = {}
+
+    def __call__(self, request, context):
+        """
+        Mock the server authorization response for validating the response content
+        """
+        response = json.dumps(self._response)
+        credentials = (lambda key: self.credentials)
+        receiver = mohawk.Receiver(
+            credentials,
+            request.headers['Authorization'],
+            request.url,
+            request.method,
+            content=request.text,
+            content_type=request.headers['Content-Type'],
+        )
+        receiver.respond(
+            content=response,
+            content_type=self.content_type,
+        )
+        context.headers['Server-Authorization'] = receiver.response_header
+        context.headers['Content-Type'] = self.content_type
+        return response


### PR DESCRIPTION
### Description of change
#### Context
This PR is part of a bigger piece of work around export wins. We plan to expose wins from the export-wins-data project and display them in DataHub.
Eventually, DataHub will call export-wins and expose wins related to a company.
#### Changes in this PR
This PR add Company matching API to export wins. This api will get a match id based on the data in the win model. This functionality will be used in the Django command to get match_ids for existing wins and also a post save functionality to get wins after a new win is saved.
**Note** This is PR is similar to the Company Matching API from datahub
https://github.com/uktrade/data-hub-api/pull/2676