### PR TITLE
Export Wins API for DataHub

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,6 +15,19 @@ export HAWK_IP_WHITELIST='1.2.3.4'
 export HAWK_ACCESS_KEY_ID='some-id'
 export HAWK_SECRET_ACCESS_KEY='some-secret'
 
+ACTIVITY_STREAM_ACCESS_KEY_ID=activity-stream-id
+ACTIVITY_STREAM_SECRET_ACCESS_KEY=activity-stream-key
+
+DATA_FLOW_API_ACCESS_KEY_ID=data-flow-api-id
+DATA_FLOW_API_SECRET_ACCESS_KEY=data-flow-api-key
+
+DATA_HUB_ACCESS_KEY_ID=data-hub-id
+DATA_HUB_SECRET_ACCESS_KEY=data-hub-key
+
+COMPANY_MATCHING_SERVICE_BASE_URL=https://company-matching-service
+COMPANY_MATCHING_HAWK_ID=company-match-id
+COMPANY_MATCHING_HAWK_KEY=company-match-key
+
 #read only
 export AWS_KEY_CSV_READ_ONLY_ACCESS=aws-read-key
 export AWS_SECRET_CSV_READ_ONLY_ACCESS=aws-read-secret

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,9 @@
 import os
 import django
+
 from django.conf import settings
 from django.core.cache import CacheHandler
+
 import pytest
 
 # We manually designate which settings we will be using in an environment variable
@@ -23,3 +25,10 @@ def local_memory_cache(monkeypatch):
         {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'},
     )
     monkeypatch.setattr('django.core.cache.caches', CacheHandler())
+
+
+@pytest.fixture
+def api_client():
+    """Django REST framework ApiClient instance."""
+    from rest_framework.test import APIClient
+    yield APIClient()

--- a/core/tests/test_hawk.py
+++ b/core/tests/test_hawk.py
@@ -43,11 +43,6 @@ def hawk_auth_sender(url, **kwargs):
     return _hawk_auth_sender(url, **extra)
 
 
-@pytest.fixture
-def api_client():
-    yield APIClient()
-
-
 @pytest.mark.django_db
 @pytest.mark.urls('core.tests.urls')
 class TestHawkAuthentication:

--- a/core/types.py
+++ b/core/types.py
@@ -9,3 +9,4 @@ class HawkScope(Enum):
     """Scopes used for Hawk views."""
     activity_stream = auto()
     data_flow_api = auto()
+    data_hub = auto()

--- a/data/settings.py
+++ b/data/settings.py
@@ -346,6 +346,12 @@ def _add_hawk_credentials(id_env_name, key_env_name, scopes):
 
 
 _add_hawk_credentials(
+    'DATA_HUB_ACCESS_KEY_ID',
+    'DATA_HUB_SECRET_ACCESS_KEY',
+    (HawkScope.data_hub, ),
+)
+
+_add_hawk_credentials(
     'ACTIVITY_STREAM_ACCESS_KEY_ID',
     'ACTIVITY_STREAM_SECRET_ACCESS_KEY',
     (HawkScope.activity_stream, ),

--- a/data/settings_test.py
+++ b/data/settings_test.py
@@ -33,6 +33,10 @@ HAWK_RECEIVER_CREDENTIALS = {
         'key': 'data-flow-key',
         'scopes': (HawkScope.data_flow_api, ),
     },
+    'data-hub-id': {
+        'key': 'data-hub-key',
+        'scopes': (HawkScope.data_hub, ),
+    },
     'mulit-scope-id': {
         'key': 'mulit-scope-key',
         'scopes': list(HawkScope.__members__.values()),

--- a/data/urls.py
+++ b/data/urls.py
@@ -2,6 +2,7 @@ import os
 
 from django.conf import settings
 from django.conf.urls import include, url
+from django.urls import path
 from django.contrib import admin
 from rest_framework.routers import DefaultRouter
 
@@ -17,7 +18,7 @@ from wins.views import (AddUserView, AdvisorViewSet, BreakdownViewSet, CSVView,
                         ChangeCustomerEmailView, CompleteWinsCSVView, ConfirmationViewSet,
                         CurrentFinancialYearWins, DetailsWinViewSet, LimitedWinViewSet,
                         NewPasswordView, SendAdminEmailView, SendCustomerEmailView,
-                        SoftDeleteWinView, WinViewSet)
+                        SoftDeleteWinView, WinViewSet, WinDataHubView)
 
 WINS_CSV_SECRET_PATH = os.environ.get('WINS_CSV_SECRET_PATH')
 
@@ -87,6 +88,11 @@ urlpatterns = [
     url(
         r'^datasets/',
         include((datasets.urls, 'datasets'), namespace='datasets')),
+    path(
+        'wins/match/<int:match_id>/',
+        WinDataHubView.as_view(),
+        name='wins-by-match-id',
+    ),
 ]
 
 if settings.API_DEBUG or WINS_CSV_SECRET_PATH:

--- a/wins/serializers.py
+++ b/wins/serializers.py
@@ -379,6 +379,7 @@ class DataHubWinSerializer(ModelSerializer):
     Win Serializer that will be consumed be used to display export wins in DataHub
     This is deisgned for datahub to proxy the api and should not need any more processing or transformation.
     """
+    title = CharField(source='name_of_export', read_only=True)
     customer = CharField(source='company_name', read_only=True)
     hvc = SerializerMethodField(read_only=True)
     response = DataHubCustomerResponseSerializer(read_only=True, source='confirmation')
@@ -397,7 +398,7 @@ class DataHubWinSerializer(ModelSerializer):
         breakdowns = DataHubBreakdownSerializer(breakdowns_exports, many=True)
         return {
             'export': {
-                'value': win.total_expected_export_value,
+                'total': win.total_expected_export_value,
                 'breakdowns': breakdowns.data
             }
         }
@@ -432,6 +433,7 @@ class DataHubWinSerializer(ModelSerializer):
         model = Win
         fields = (
             'id',
+            'title',
             'date',
             'created',
             'country',

--- a/wins/serializers.py
+++ b/wins/serializers.py
@@ -388,6 +388,10 @@ class DataHubWinSerializer(ModelSerializer):
     value = SerializerMethodField(read_only=True)
 
     def get_value(self, win):
+        """
+        Return breakdown vaules in a value nested dict.
+        Use only breakdown type EXPORT
+        """
         breakdown_type = BREAKDOWN_TYPES[0]
         breakdowns_exports = win.breakdowns.filter(type=breakdown_type[0])
         breakdowns = DataHubBreakdownSerializer(breakdowns_exports, many=True)
@@ -399,6 +403,7 @@ class DataHubWinSerializer(ModelSerializer):
         }
 
     def get_officer(self, win):
+        """Return lead officer in a officer nested dict."""
         return {
             'name': win.lead_officer_name,
             'email': win.lead_officer_email_address,
@@ -409,12 +414,14 @@ class DataHubWinSerializer(ModelSerializer):
         }
 
     def get_hvc(self, win):
+        """Return hvc data in a hvc nested dict."""
         return {
             'code': win.hvc,
             'name': win.hvo_programme,
         }
 
     def get_contact(self, win):
+        """Return contact information in a contact nested dict."""
         return {
             'name': win.customer_name,
             'email': win.customer_email_address,

--- a/wins/serializers.py
+++ b/wins/serializers.py
@@ -1,7 +1,12 @@
 from rest_framework.serializers import (
-    CharField, ModelSerializer, SerializerMethodField
+    BooleanField,
+    DateField,
+    DateTimeField,
+    CharField,
+    ModelSerializer,
+    SerializerMethodField
 )
-from .constants import EXPERIENCE_CATEGORIES, WITH_OUR_SUPPORT
+from .constants import EXPERIENCE_CATEGORIES, WITH_OUR_SUPPORT, BREAKDOWN_TYPES
 from .models import Win, Breakdown, Advisor, CustomerResponse
 
 
@@ -341,3 +346,97 @@ class CustomerResponseSerializer(ModelSerializer):
             "marketing_source",
             "other_marketing_source"
         )
+
+
+class DataHubBreakdownSerializer(ModelSerializer):
+    """Serialiser for CustomerResponse to expose confirmation status and date"""
+    class Meta(object):
+        model = Breakdown
+        fields = (
+            "year",
+            "value"
+        )
+        read_only_fields = fields
+
+
+class DataHubCustomerResponseSerializer(ModelSerializer):
+    """Serialiser for CustomerResponse to expose confirmation status and date"""
+    confirmed = BooleanField(source='agree_with_win', read_only=True)
+    date = DateTimeField(source='created', read_only=True)
+
+    class Meta(object):
+        model = CustomerResponse
+        fields = (
+            'confirmed',
+            'date'
+        )
+        read_only_fields = fields
+
+
+class DataHubWinSerializer(ModelSerializer):
+    """
+    Read-only serialiser for the Hawk-authenticated win view.
+    Win Serializer that will be consumed be used to display export wins in DataHub
+    This is deisgned for datahub to proxy the api and should not need any more processing or transformation.
+    """
+    customer = CharField(source='company_name', read_only=True)
+    hvc = SerializerMethodField(read_only=True)
+    response = DataHubCustomerResponseSerializer(read_only=True, source='confirmation')
+    officer = SerializerMethodField(read_only=True)
+
+    contact = SerializerMethodField(read_only=True)
+    value = SerializerMethodField(read_only=True)
+
+    def get_value(self, win):
+        breakdown_type = BREAKDOWN_TYPES[0]
+        breakdowns_exports = win.breakdowns.filter(type=breakdown_type[0])
+        breakdowns = DataHubBreakdownSerializer(breakdowns_exports, many=True)
+        return {
+            'export': {
+                'value': win.total_expected_export_value,
+                'breakdowns': breakdowns.data
+            }
+        }
+
+    def get_officer(self, win):
+        return {
+            'name': win.lead_officer_name,
+            'email': win.lead_officer_email_address,
+            'team': {
+                'type': win.team_type,
+                'sub_type': win.hq_team
+            }
+        }
+
+    def get_hvc(self, win):
+        return {
+            'code': win.hvc,
+            'name': win.hvo_programme,
+        }
+
+    def get_contact(self, win):
+        return {
+            'name': win.customer_name,
+            'email': win.customer_email_address,
+            'job_title': win.customer_job_title,
+        }
+
+    class Meta(object):
+        model = Win
+        fields = (
+            'id',
+            'date',
+            'created',
+            'country',
+            'sector',
+            'business_potential',
+            'business_type',
+            'name_of_export',
+            'officer',
+            'contact',
+            'value',
+            'customer',
+            'response',
+            'hvc',
+        )
+        read_only_fields = fields

--- a/wins/tests/test_wins_datahub_view.py
+++ b/wins/tests/test_wins_datahub_view.py
@@ -98,7 +98,12 @@ class TestWinDataHubView:
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
         )
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == []
+        assert response.json() == {
+            'count': 0,
+            'next': None,
+            'previous': None,
+            'results': []
+        }
 
     def test_match_win_view(self, win, api_client):
         """Test export wins are returned in the expected format"""
@@ -112,48 +117,54 @@ class TestWinDataHubView:
         )
         assert response.status_code == status.HTTP_200_OK
 
-        assert response.json() == [
-            {
-                'id': str(win.id),
-                'date': format_date_or_datetime(win.date.date()),
-                'created': format_date_or_datetime(win.created),
-                'country': win.country,
-                'sector': win.sector,
-                'business_potential': win.business_potential,
-                'business_type': win.business_type,
-                'name_of_export': win.name_of_export,
-                'officer': {
-                    'name': win.lead_officer_name,
-                    'email': win.lead_officer_email_address,
-                    'team': {
-                        'type': win.team_type,
-                        'sub_type': win.hq_team
+        assert response.json() == {
+            'count': 1,
+            'next': None,
+            'previous': None,
+            'results': [
+                {
+                    'id': str(win.id),
+                    'title': win.name_of_export,
+                    'date': format_date_or_datetime(win.date.date()),
+                    'created': format_date_or_datetime(win.created),
+                    'country': win.country,
+                    'sector': win.sector,
+                    'business_potential': win.business_potential,
+                    'business_type': win.business_type,
+                    'name_of_export': win.name_of_export,
+                    'officer': {
+                        'name': win.lead_officer_name,
+                        'email': win.lead_officer_email_address,
+                        'team': {
+                            'type': win.team_type,
+                            'sub_type': win.hq_team
+                        }
+                    },
+                    'contact': {
+                        'name': win.customer_name,
+                        'email': win.customer_email_address,
+                        'job_title': win.customer_job_title,
+                    },
+                    'value': {
+                        'export': {
+                            'total': win.total_expected_export_value,
+                            'breakdowns': [
+                                {
+                                    'year': breakdown.year,
+                                    'value': breakdown.value
+                                } for breakdown in win.breakdowns.all()
+                            ]
+                        }
+                    },
+                    'customer': win.company_name,
+                    'response': {
+                        'confirmed': win.confirmation.agree_with_win,
+                        'date': format_date_or_datetime(win.confirmation.created)
+                    },
+                    'hvc': {
+                        'code': win.hvc,
+                        'name': win.hvo_programme,
                     }
-                },
-                'contact': {
-                    'name': win.customer_name,
-                    'email': win.customer_email_address,
-                    'job_title': win.customer_job_title,
-                },
-                'value': {
-                    'export': {
-                        'value': win.total_expected_export_value,
-                        'breakdowns': [
-                            {
-                                'year': breakdown.year,
-                                'value': breakdown.value
-                            } for breakdown in win.breakdowns.all()
-                        ]
-                    }
-                },
-                'customer': win.company_name,
-                'response': {
-                    'confirmed': win.confirmation.agree_with_win,
-                    'date': format_date_or_datetime(win.confirmation.created)
-                },
-                'hvc': {
-                    'code': win.hvc,
-                    'name': win.hvo_programme,
                 }
-            }
-        ]
+            ]
+        }

--- a/wins/tests/test_wins_datahub_view.py
+++ b/wins/tests/test_wins_datahub_view.py
@@ -1,0 +1,101 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from wins.factories import BreakdownFactory, CustomerResponseFactory, WinFactory
+from wins.tests.utils import format_date_or_datetime
+from test_helpers.hawk_utils import hawk_auth_sender as _hawk_auth_sender
+
+
+@pytest.fixture
+def win():
+    """Set up datbase records for testing exports wins in data hub"""
+    win = WinFactory.create(
+        id='00000000-0000-0000-0000-000000000000',
+        company_name='Name 1',
+        cdms_reference='00000000',
+        customer_email_address='test@example.com',
+        match_id=1
+    )
+    BreakdownFactory.create(year=2020, win=win)
+    BreakdownFactory.create(year=2021, win=win)
+    CustomerResponseFactory.create(agree_with_win=True, win=win)
+    return win
+
+
+def _url(match_id):
+    path = reverse('wins-by-match-id', kwargs={'match_id': match_id})
+    return 'http://testserver' + path
+
+
+def hawk_auth_sender(url, **kwargs):
+    """Pass credentials to hawk sender."""
+    extra = {
+        'key_id': 'data-hub-id',
+        'secret_key': 'data-hub-key',
+        **kwargs
+    }
+    return _hawk_auth_sender(url, **extra)
+
+
+@pytest.mark.django_db
+class TestWinDataHubView:
+    """Test exports wins endpoint for data hub"""
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, api_client, verb):
+        """Test only get is supported"""
+        url = _url(3)
+        auth = hawk_auth_sender(url, method=verb).request_header
+        response = getattr(api_client, verb)(
+            url,
+            HTTP_AUTHORIZATION=auth,
+            HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+        )
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_wrong_scope(self, api_client):
+        """Test view returns 403 if not in scope"""
+        url = _url(3)
+        auth = hawk_auth_sender(
+            url,
+            key_id='no-scope-id',
+            secret_key='no-scope-key',
+        ).request_header
+
+        response = api_client.get(
+            url,
+            content_type='',
+            HTTP_AUTHORIZATION=auth,
+            HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_invalid_key(self, api_client):
+        """Test view returns 401 if the key is invalid"""
+        url = _url(3)
+        auth = hawk_auth_sender(
+            url,
+            key_id='invalid',
+        ).request_header
+
+        response = api_client.get(
+            url,
+            content_type='',
+            HTTP_AUTHORIZATION=auth,
+            HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_match_win_view_returns_an_empty_list(self, api_client):
+        """Test export wins returns an empty list if no match is found"""
+        url = _url(3)
+        auth = hawk_auth_sender(url).request_header
+        response = api_client.get(
+            url,
+            content_type='',
+            HTTP_AUTHORIZATION=auth,
+            HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []

--- a/wins/tests/test_wins_datahub_view.py
+++ b/wins/tests/test_wins_datahub_view.py
@@ -99,3 +99,61 @@ class TestWinDataHubView:
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
+
+    def test_match_win_view(self, win, api_client):
+        """Test export wins are returned in the expected format"""
+        url = _url(1)
+        auth = hawk_auth_sender(url).request_header
+        response = api_client.get(
+            url,
+            content_type='',
+            HTTP_AUTHORIZATION=auth,
+            HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        assert response.json() == [
+            {
+                'id': str(win.id),
+                'date': format_date_or_datetime(win.date.date()),
+                'created': format_date_or_datetime(win.created),
+                'country': win.country,
+                'sector': win.sector,
+                'business_potential': win.business_potential,
+                'business_type': win.business_type,
+                'name_of_export': win.name_of_export,
+                'officer': {
+                    'name': win.lead_officer_name,
+                    'email': win.lead_officer_email_address,
+                    'team': {
+                        'type': win.team_type,
+                        'sub_type': win.hq_team
+                    }
+                },
+                'contact': {
+                    'name': win.customer_name,
+                    'email': win.customer_email_address,
+                    'job_title': win.customer_job_title,
+                },
+                'value': {
+                    'export': {
+                        'value': win.total_expected_export_value,
+                        'breakdowns': [
+                            {
+                                'year': breakdown.year,
+                                'value': breakdown.value
+                            } for breakdown in win.breakdowns.all()
+                        ]
+                    }
+                },
+                'customer': win.company_name,
+                'response': {
+                    'confirmed': win.confirmation.agree_with_win,
+                    'date': format_date_or_datetime(win.confirmation.created)
+                },
+                'hvc': {
+                    'code': win.hvc,
+                    'name': win.hvo_programme,
+                }
+            }
+        ]

--- a/wins/tests/utils.py
+++ b/wins/tests/utils.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from rest_framework.fields import DateField, DateTimeField
+
+
+def format_date_or_datetime(value):
+    """
+    Formats a date or datetime using DRF fields.
+
+    This is for use in tests when comparing dates and datetimes with JSON-formatted values.
+    """
+    if isinstance(value, datetime):
+        return DateTimeField().to_representation(value)
+    return DateField().to_representation(value)

--- a/wins/views/__init__.py
+++ b/wins/views/__init__.py
@@ -17,4 +17,5 @@ from .model_views import (
     BreakdownViewSet,
     AdvisorViewSet,
     DetailsWinViewSet,
+    WinDataHubView,
 )

--- a/wins/views/model_views.py
+++ b/wins/views/model_views.py
@@ -178,6 +178,7 @@ class WinDataHubView(ListAPIView):
 
     @decorator_from_middleware(HawkResponseMiddleware)
     def get(self, request, *args, **kwargs):
+        """Add HawkResponseMiddleware for get request"""
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):

--- a/wins/views/model_views.py
+++ b/wins/views/model_views.py
@@ -171,7 +171,7 @@ class WinDataHubView(ListAPIView):
         Read only export wins view for on datahub
     """
     serializer_class = DataHubWinSerializer
-
+    pagination_class = BigPagination
     authentication_classes = (HawkAuthentication,)
     permission_classes = (HawkScopePermission,)
     required_hawk_scope = HawkScope.data_hub

--- a/wins/views/model_views.py
+++ b/wins/views/model_views.py
@@ -1,5 +1,7 @@
+from django.utils.decorators import method_decorator, decorator_from_middleware
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
+from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ModelViewSet
@@ -8,10 +10,13 @@ from .. import notifications
 from ..filters import CustomerResponseFilterSet
 from ..models import Win, Breakdown, Advisor, CustomerResponse, Notification
 from ..serializers import (
-    WinSerializer, LimitedWinSerializer, BreakdownSerializer,
+    WinSerializer, DataHubWinSerializer, LimitedWinSerializer, BreakdownSerializer,
     AdvisorSerializer, CustomerResponseSerializer, DetailWinSerializer
 )
+from alice.middleware import alice_exempt
 from alice.views import AliceMixin
+from core.hawk import HawkAuthentication, HawkResponseMiddleware, HawkScopePermission
+from core.types import HawkScope
 
 
 class StandardPagination(PageNumberPagination):
@@ -154,3 +159,28 @@ class AdvisorViewSet(AliceMixin, ModelViewSet):
         # which requires overriding the standard method to give the
         # `for_real` flag
         instance.delete(for_real=True)
+
+
+@method_decorator(alice_exempt, name='dispatch')
+class WinDataHubView(ListAPIView):
+    """
+        This endpoint is used to expose win inside datahub
+        To match companies it uses the match id since there in
+        no one to one record with datahub. In the future DNB number
+        may be used.
+        Read only export wins view for on datahub
+    """
+    serializer_class = DataHubWinSerializer
+
+    authentication_classes = (HawkAuthentication,)
+    permission_classes = (HawkScopePermission,)
+    required_hawk_scope = HawkScope.data_hub
+
+    @decorator_from_middleware(HawkResponseMiddleware)
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        """Get wins by match id a empty list if not matches are found"""
+        match_id = self.kwargs['match_id']
+        return Win.objects.filter(match_id=match_id)


### PR DESCRIPTION
### Description of change
#### Context
This PR is part of a bigger piece of work around export wins. We plan to expose wins from the export-wins-data project and display them in DataHub.
Eventually, DataHub will call export-wins and expose wins related to a company.
See the presentation for more context on the approach.
https://docs.google.com/presentation/d/132Kzu0dW-nt0qVzszjV0EdJCcC87FqIAZcNslcFQOA0/edit?usp=sharing
#### Changes in this PR
In this PR add an hawk enabled export-wins endpoint to export-wins-data. This endpoint will be consumed by datahub.
The json format is a specification authored by @web-bert. It is designed to be forward by datahub without any need of further validation or transformation.
  
This PR is dependant on
#961
#962
being merged in.
