### PR TITLE
Add support for multiple HAWK creds and permission scope 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ jobs:
           HAWK_IP_WHITELIST: 1.2.3.4
           HAWK_ACCESS_KEY_ID: some-id
           HAWK_SECRET_ACCESS_KEY: some-secret
+          ACTIVITY_STREAM_ACCESS_KEY_ID: activity-stream-id
+          ACTIVITY_STREAM_SECRET_ACCESS_KEY: activity-stream-key
+          DATA_FLOW_API_ACCESS_KEY_ID: data-flow-api-id
+          DATA_FLOW_API_SECRET_ACCESS_KEY: data-flow-api-key
           AWS_KEY_CSV_READ_ONLY_ACCESS: aws-read-key
           AWS_SECRET_CSV_READ_ONLY_ACCESS: aws-read-secret
           AWS_REGION_CSV: aws-region
@@ -45,7 +49,7 @@ jobs:
             - ~/cache/pip
       - run:
           name: Run tests
-          command: python -W ignore manage.py test
+          command: pytest
 
 workflows:
   version: 2

--- a/activity_stream/views.py
+++ b/activity_stream/views.py
@@ -9,7 +9,8 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from alice.middleware import alice_exempt
-from core.hawk import HawkAuthentication, HawkResponseMiddleware
+from core.hawk import HawkAuthentication, HawkResponseMiddleware, HawkScopePermission
+from core.types import HawkScope
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,8 @@ class ActivityStreamViewSet(ViewSet):
     """List-only view set for the activity stream"""
 
     authentication_classes = (HawkAuthentication,)
-    permission_classes = ()
+    permission_classes = (HawkScopePermission,)
+    required_hawk_scope = HawkScope.activity_stream
 
     @decorator_from_middleware(HawkResponseMiddleware)
     def list(self, request):

--- a/core/types.py
+++ b/core/types.py
@@ -1,0 +1,11 @@
+"""
+This module contains types that are used in the config package.
+"""
+
+from enum import auto, Enum
+
+
+class HawkScope(Enum):
+    """Scopes used for Hawk views."""
+    activity_stream = auto()
+    data_flow_api = auto()

--- a/data/settings_test.py
+++ b/data/settings_test.py
@@ -23,3 +23,22 @@ PASSWORD_HASHERS = [
 ]
 
 CACHES = {'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}}
+
+HAWK_RECEIVER_CREDENTIALS = {
+    'activity-stream-id': {
+        'key': 'activity-stream-key',
+        'scopes': (HawkScope.activity_stream, ),
+    },
+    'data-flow-id': {
+        'key': 'data-flow-key',
+        'scopes': (HawkScope.data_flow_api, ),
+    },
+    'mulit-scope-id': {
+        'key': 'mulit-scope-key',
+        'scopes': (HawkScope.activity_stream, HawkScope.data_flow_api, ),
+    },
+    'no-scope-id': {
+        'key': 'no-scope-key',
+        'scopes': (),
+    },
+}

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -5,7 +5,8 @@ from django.utils.decorators import method_decorator, decorator_from_middleware
 from django_countries import countries
 from rest_framework.views import APIView
 
-from core.hawk import HawkAuthentication, HawkResponseMiddleware
+from core.hawk import HawkAuthentication, HawkResponseMiddleware, HawkScopePermission
+from core.types import HawkScope
 from alice.middleware import alice_exempt
 from datasets.pagination import WinsDatasetViewCursorPagination, DatasetViewCursorPagination
 
@@ -35,8 +36,9 @@ def get_choices_as_case_expression(model, field_name, lookup_field=None):
 @method_decorator(alice_exempt, name='dispatch')
 class DatasetView(APIView):
     authentication_classes = (HawkAuthentication,)
-    permission_classes = ()
+    permission_classes = (HawkScopePermission,)
     pagination_class = DatasetViewCursorPagination
+    required_hawk_scope = HawkScope.data_flow_api
 
     @decorator_from_middleware(HawkResponseMiddleware)
     def get(self, request):


### PR DESCRIPTION
### Description of change
#### Context
For Export wins we need to make an endpoint for data hub to consume.
The problem is that Exports wins only supports one HAWK key and secret at a time. The problem is sharing credential is that it not clear what service is impacted if these keys are revoked.

####Changed
In this PR I've tried to refactor in without doing a major refactor. 
It looks like the HAWK module was lifted out of the datahub-api project because there is a mix of unittest test and pytest modules.

I've switch to pytest since this covers both tests.