### PR TITLE
Human readable data hub data

### DIFF
--- a/fixturedb/factories/win.py
+++ b/fixturedb/factories/win.py
@@ -61,6 +61,7 @@ def create_win_factory(user, sector_choices=None, default_date=None, default_tea
         if export_experience:
             win.export_experience = export_experience
 
+        win.match_id = 1
         win.save()
 
         if confirm:

--- a/wins/serializers.py
+++ b/wins/serializers.py
@@ -433,21 +433,20 @@ class DataHubWinSerializer(ModelSerializer):
 
     def get_hvc(self, win):
         """Return hvc data in a hvc nested dict."""
-        if not win.hvc:
-            return None
-        # win hvc is formed of hvc code + two digits of financial year
-        hvc = win.hvc[:-2]
-        fy = win.hvc[-2:]
-        current_hvc = HVC.objects.filter(
-            campaign_id=hvc,
-            financial_year=fy,
-        ).first()
-        if not current_hvc:
-            return None
-        return {
-            'code': current_hvc.campaign_id,
-            'name': current_hvc.name,
-        }
+        if win.hvc:
+            # win hvc is formed of hvc code + two digits of financial year
+            hvc = win.hvc[:-2]
+            fy = win.hvc[-2:]
+            current_hvc = HVC.objects.filter(
+                campaign_id=hvc,
+                financial_year=fy,
+            ).first()
+            if current_hvc:
+                return {
+                    'code': current_hvc.campaign_id,
+                    'name': current_hvc.name,
+                }
+        return None
 
     def get_contact(self, win):
         """Return contact information in a contact nested dict."""
@@ -461,24 +460,24 @@ class DataHubWinSerializer(ModelSerializer):
         """Return country name for the code."""
         if win.country:
             dc = DjangoCountry(win.country)
-            return dc.name
-        else:
-            return None
+            if dc.name:
+                return dc.name
+        return None
 
     def get_sector(self, win):
         """Return sector name for the code."""
         if win.sector:
             sector = Sector.objects.get(id=win.sector)
             return sector.name
-        else:
-            return None
+        return None
 
     def get_business_potential(self, win):
         """Return human readable name for business type."""
         business_potential_dict = dict(BUSINESS_POTENTIAL)
-        if not win.business_potential:
-            return None
-        return business_potential_dict[win.business_potential]
+        if win.business_potential:
+            return business_potential_dict[win.business_potential]
+
+        return None
 
     class Meta(object):
         model = Win

--- a/wins/serializers.py
+++ b/wins/serializers.py
@@ -15,6 +15,8 @@ from wins.constants import (
     BREAKDOWN_TYPES,
     BUSINESS_POTENTIAL,
     EXPERIENCE_CATEGORIES,
+    HQ_TEAM_REGION_OR_POST,
+    TEAMS,
     WITH_OUR_SUPPORT,
 )
 from wins.models import Advisor, Breakdown, CustomerResponse, HVC, Win
@@ -418,12 +420,14 @@ class DataHubWinSerializer(ModelSerializer):
 
     def get_officer(self, win):
         """Return lead officer in a officer nested dict."""
+        teams_dict = dict(TEAMS)
+        hq_dict = dict(HQ_TEAM_REGION_OR_POST)
         return {
             'name': win.lead_officer_name,
             'email': win.lead_officer_email_address,
             'team': {
-                'type': win.team_type,
-                'sub_type': win.hq_team,
+                'type': teams_dict[win.team_type],
+                'sub_type': hq_dict[win.hq_team],
             },
         }
 

--- a/wins/tests/test_wins_datahub_view.py
+++ b/wins/tests/test_wins_datahub_view.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from fixturedb.factories.win import create_win_factory
-from wins.constants import BUSINESS_POTENTIAL
+from wins.constants import BUSINESS_POTENTIAL, HQ_TEAM_REGION_OR_POST, TEAMS
 from wins.factories import BreakdownFactory, CustomerResponseFactory, HVCFactory, UserFactory, WinFactory
 from wins.tests.utils import format_date_or_datetime
 from test_helpers.hawk_utils import hawk_auth_sender as _hawk_auth_sender
@@ -126,6 +126,8 @@ class TestWinDataHubView:
         """Test export wins are returned in the expected format."""
         hvc, win = hvc_win
         business_potential_dict = dict(BUSINESS_POTENTIAL)
+        teams_dict = dict(TEAMS)
+        hq_dict = dict(HQ_TEAM_REGION_OR_POST)
         url = _url(1)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
@@ -155,8 +157,8 @@ class TestWinDataHubView:
                         'name': win.lead_officer_name,
                         'email': win.lead_officer_email_address,
                         'team': {
-                            'type': win.team_type,
-                            'sub_type': win.hq_team,
+                            'type': teams_dict[win.team_type],
+                            'sub_type': hq_dict[win.hq_team],
                         },
                     },
                     'contact': {
@@ -192,6 +194,8 @@ class TestWinDataHubView:
         """Test export wins are returned in the expected format."""
         win = non_hvc_win
         business_potential_dict = dict(BUSINESS_POTENTIAL)
+        teams_dict = dict(TEAMS)
+        hq_dict = dict(HQ_TEAM_REGION_OR_POST)
         url = _url(1)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
@@ -221,8 +225,8 @@ class TestWinDataHubView:
                         'name': win.lead_officer_name,
                         'email': win.lead_officer_email_address,
                         'team': {
-                            'type': win.team_type,
-                            'sub_type': win.hq_team,
+                            'type': teams_dict[win.team_type],
+                            'sub_type': hq_dict[win.hq_team],
                         },
                     },
                     'contact': {

--- a/wins/views/model_views.py
+++ b/wins/views/model_views.py
@@ -154,22 +154,25 @@ class AdvisorViewSet(AliceMixin, ModelViewSet):
     http_method_names = ("get", "post", "patch", "put", "delete")
 
     def perform_destroy(self, instance):
-        # when Win is deleted, it's advisors get soft-deleted
-        # but when a user deletes the advisor, want to delete it for real
-        # which requires overriding the standard method to give the
-        # `for_real` flag
+        """
+        when Win is deleted, it's advisors get soft-deleted
+        but when a user deletes the advisor, want to delete it for real
+        which requires overriding the standard method to give the
+        `for_real` flag
+        """
         instance.delete(for_real=True)
 
 
 @method_decorator(alice_exempt, name='dispatch')
 class WinDataHubView(ListAPIView):
     """
-        This endpoint is used to expose win inside datahub
-        To match companies it uses the match id since there in
-        no one to one record with datahub. In the future DNB number
-        may be used.
-        Read only export wins view for on datahub
+    This endpoint is used to expose win inside datahub
+    To match companies it uses the match id since there in
+    no one to one record with datahub. In the future DNB number
+    may be used.
+    Read only export wins view for on datahub
     """
+
     serializer_class = DataHubWinSerializer
     pagination_class = BigPagination
     authentication_classes = (HawkAuthentication,)
@@ -178,10 +181,10 @@ class WinDataHubView(ListAPIView):
 
     @decorator_from_middleware(HawkResponseMiddleware)
     def get(self, request, *args, **kwargs):
-        """Add HawkResponseMiddleware for get request"""
+        """Add HawkResponseMiddleware for get request."""
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
-        """Get wins by match id a empty list if not matches are found"""
+        """Get wins by match id a empty list if not matches are found."""
         match_id = self.kwargs['match_id']
         return Win.objects.filter(match_id=match_id)


### PR DESCRIPTION
Fixing data hub API endpoint to expose human readable data for `HVC`, `Sector`, `Company Type`, `Country`, `team_type` and team_sub_type` fields. Also covering non_hvc wins, by exposing `null` for `HVC` field.