### PR TITLE
Add redis utils to choose redis instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           DEBUG: True
           API_DEBUG: True
           DATABASE_URL: 'postgres://postgres@127.0.0.1:5432/export-wins-data'
-          VCAP_SERVICES: '{"redis": [{"credentials": {"uri": "redis://127.0.0.1:7000/"}}]}'
+          VCAP_SERVICES: '{"redis": [{"credentials": {"uri": "redis://127.0.0.1:7000/", "name": "redis"}}]}'
           HAWK_IP_WHITELIST: 1.2.3.4
           HAWK_ACCESS_KEY_ID: some-id
           HAWK_SECRET_ACCESS_KEY: some-secret
@@ -28,6 +28,7 @@ jobs:
           AWS_SECRET_CSV_READ_ONLY_ACCESS: aws-read-secret
           AWS_REGION_CSV: aws-region
           SESSION_COOKIE_SECURE: False
+          REDIS_SERVICE_NAME: 'redis'
       - image: postgres:10
         environment:
           POSTGRES_DB: export-wins-data

--- a/.env.template
+++ b/.env.template
@@ -9,7 +9,7 @@ export DEBUG=True
 export API_DEBUG=True
 export POSTGRES_DB='export-wins-data'
 export DATABASE_URL='postgres://postgres@127.0.0.1:5432/export-wins-data'
-export VCAP_SERVICES='{"redis": [{"credentials": {"uri": "redis://127.0.0.1:7000/"}}]}'
+export VCAP_SERVICES='{"redis": [{"credentials": {"uri": "redis://127.0.0.1:7000/"} "name": "redis" }]}'
 
 export HAWK_IP_WHITELIST='1.2.3.4'
 export HAWK_ACCESS_KEY_ID='some-id'

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker run -d -p 7000-7005:7000-7005 -e CLUSTER_ONLY=true -e IP=0.0.0.0 grokzen/
 with your environment setup as it would be in PaaS
 
 ```bash
-export VCAP_SERVICES='{"redis": [{"credentials": {"uri": "redis://127.0.0.1:7000/"}}]}'
+export VCAP_SERVICES='{"redis": [{"credentials": {"uri": "redis://127.0.0.1:7000/", name: "redis"}}]}'
 ```
 
 #### Dummy data

--- a/core/tests/test_redis_instance_helper.py
+++ b/core/tests/test_redis_instance_helper.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from data.settings import get_redis_instance
+
+
+@pytest.fixture
+def vcap_service(monkeypatch):
+    VCAP_SERVICES = {
+        'redis': [
+            {
+                'credentials': {
+                    'uri': 'redis://redis-1'
+                },
+                'name': 'redis-1',
+            },
+            {
+                'credentials': {
+                    'uri': 'redis://redis-2'
+                },
+                'name': 'redis-2',
+            },
+        ]
+    }
+    monkeypatch.setenv('VCAP_SERVICES', json.dumps(VCAP_SERVICES))
+
+
+class TestRedisInstanceHelper:
+    """Switch redis instance base on environment variable."""
+
+    def test_credentials_are_returned(self, monkeypatch, vcap_service):
+        """Test instance is returned when the name is matched."""
+        monkeypatch.setenv("REDIS_SERVICE_NAME", "redis-2")
+        credentials = get_redis_instance()
+        assert credentials.get('uri') == 'redis://redis-2'
+
+    def test_missing_env_raises_error(self, monkeypatch, vcap_service):
+        """Test missing env raises error."""
+        monkeypatch.delenv("REDIS_SERVICE_NAME")
+
+        with pytest.raises(ImproperlyConfigured):
+            get_redis_instance()
+
+    def test_return_first_instance_when_there_is_one(self, monkeypatch):
+        """Test if only one instance is available return the frist one."""
+        VCAP_SERVICES = {
+            'redis': [
+                {
+                    'credentials': {
+                        'uri': 'redis://redis-1'
+                    },
+                    'name': 'redis-1',
+                },
+            ]
+        }
+        monkeypatch.setenv('VCAP_SERVICES', json.dumps(VCAP_SERVICES))
+        monkeypatch.setenv("REDIS_SERVICE_NAME", "redis-2")
+        credentials = get_redis_instance()
+        assert credentials.get('uri') == 'redis://redis-1'


### PR DESCRIPTION
## Description of change
This PR allows migrating Redis cluster mode to Redis stand alone service with minimal disruptions by using an environment variable to set the Redis service. 
This is need because the app is using the first Redis service in the vcap_service list.
by setting the REDIS_SERVICE_NAME the app can select which instance to use when multiple redis instances are deployed.

## Redis deployment plan

1.  Set the REDIS_SERVICE_NAME across all environments to the current Redis instance (cluster mode).
2. Merge this pr and deploy it to all environments.
3. Create bind Redis stand alone service safely without disruption (This creates 2 services).  

4. Merge in https://github.com/uktrade/export-wins-data/pull/972  
5. Update REDIS_SERVICE_NAME name to new instance  (Redis Standalone)
6. Deploy  https://github.com/uktrade/export-wins-data/pull/972  

