### PR TITLE
Allow Data Hub wins API to take multiple match ids

### DIFF
--- a/data/urls.py
+++ b/data/urls.py
@@ -89,7 +89,7 @@ urlpatterns = [
         r'^datasets/',
         include((datasets.urls, 'datasets'), namespace='datasets')),
     path(
-        'wins/match/<int:match_id>/',
+        'wins/match',
         WinDataHubView.as_view(),
         name='wins-by-match-id',
     ),

--- a/fixturedb/factories/win.py
+++ b/fixturedb/factories/win.py
@@ -17,7 +17,8 @@ def create_win_factory(user, sector_choices=None, default_date=None, default_tea
 
     def inner(hvc_code, sector_id=None, win_date=None, export_value=None,
               confirm=False, notify_date=None, response_date=None, country=None,
-              fin_year=2016, agree_with_win=True, team_type=None, hq_team=None, export_experience=None):
+              fin_year=2016, agree_with_win=True, team_type=None, hq_team=None,
+              export_experience=None, match_id=1):
         """ generic function creating `Win` """
         if not sector_id:
             sector_id = FuzzyChoice(sector_choices)
@@ -61,7 +62,7 @@ def create_win_factory(user, sector_choices=None, default_date=None, default_tea
         if export_experience:
             win.export_experience = export_experience
 
-        win.match_id = 1
+        win.match_id = match_id
         win.save()
 
         if confirm:

--- a/wins/tests/test_wins_datahub_view.py
+++ b/wins/tests/test_wins_datahub_view.py
@@ -1,16 +1,21 @@
-import pytest
 from django.urls import reverse
-from rest_framework import status
+from django.utils.http import urlencode
 
 from fixturedb.factories.win import create_win_factory
-from wins.constants import BUSINESS_POTENTIAL, HQ_TEAM_REGION_OR_POST, TEAMS
-from wins.factories import BreakdownFactory, CustomerResponseFactory, HVCFactory, UserFactory, WinFactory
-from wins.tests.utils import format_date_or_datetime
+
+import pytest
+
+from rest_framework import status
+
 from test_helpers.hawk_utils import hawk_auth_sender as _hawk_auth_sender
+
+from wins.constants import BUSINESS_POTENTIAL, HQ_TEAM_REGION_OR_POST, TEAMS
+from wins.factories import BreakdownFactory, HVCFactory, UserFactory
+from wins.tests.utils import format_date_or_datetime
 
 
 def _url(match_id):
-    path = reverse('wins-by-match-id', kwargs={'match_id': match_id})
+    path = u'%s?%s' % (reverse('wins-by-match-id'), urlencode({'match_id': match_id}))
     return 'http://testserver' + path
 
 
@@ -26,11 +31,11 @@ def hawk_auth_sender(url, **kwargs):
 
 @pytest.mark.django_db
 class TestWinDataHubView:
-    """Test exports wins endpoint for data hub"""
+    """Test exports wins endpoint for data hub."""
 
     @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
     def test_verbs_not_allowed(self, api_client, verb):
-        """Test only get is supported"""
+        """Test only get is supported."""
         url = _url(3)
         auth = hawk_auth_sender(url, method=verb).request_header
         response = getattr(api_client, verb)(
@@ -41,8 +46,9 @@ class TestWinDataHubView:
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     def test_wrong_scope(self, api_client):
-        """Test view returns 403 if not in scope"""
-        url = _url(3)
+        """Test view returns 403 if not in scope."""
+        match_id = 3
+        url = _url(match_id)
         auth = hawk_auth_sender(
             url,
             key_id='no-scope-id',
@@ -54,12 +60,14 @@ class TestWinDataHubView:
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_invalid_key(self, api_client):
-        """Test view returns 401 if the key is invalid"""
-        url = _url(3)
+        """Test view returns 401 if the key is invalid."""
+        match_id = 3
+        url = _url(match_id)
         auth = hawk_auth_sender(
             url,
             key_id='invalid',
@@ -70,18 +78,21 @@ class TestWinDataHubView:
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_match_win_view_returns_an_empty_list(self, api_client):
         """Test export wins returns an empty list if no match is found."""
-        url = _url(3)
+        match_id = 3
+        url = _url(match_id)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
             url,
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -108,13 +119,15 @@ class TestWinDataHubView:
         business_potential_dict = dict(BUSINESS_POTENTIAL)
         teams_dict = dict(TEAMS)
         hq_dict = dict(HQ_TEAM_REGION_OR_POST)
-        url = _url(1)
+        match_id = 1
+        url = _url(match_id)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
             url,
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -182,13 +195,15 @@ class TestWinDataHubView:
         business_potential_dict = dict(BUSINESS_POTENTIAL)
         teams_dict = dict(TEAMS)
         hq_dict = dict(HQ_TEAM_REGION_OR_POST)
-        url = _url(1)
+        match_id = 1
+        url = _url(match_id)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
             url,
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -253,13 +268,15 @@ class TestWinDataHubView:
         business_potential_dict = dict(BUSINESS_POTENTIAL)
         teams_dict = dict(TEAMS)
         hq_dict = dict(HQ_TEAM_REGION_OR_POST)
-        url = _url(1)
+        match_id = 1
+        url = _url(match_id)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
             url,
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -330,13 +347,15 @@ class TestWinDataHubView:
         business_potential_dict = dict(BUSINESS_POTENTIAL)
         teams_dict = dict(TEAMS)
         hq_dict = dict(HQ_TEAM_REGION_OR_POST)
-        url = _url(1)
+        match_id = 1
+        url = _url(match_id)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
             url,
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -413,13 +432,15 @@ class TestWinDataHubView:
 
         teams_dict = dict(TEAMS)
         hq_dict = dict(HQ_TEAM_REGION_OR_POST)
-        url = _url(1)
+        match_id = 1
+        url = _url(match_id)
         auth = hawk_auth_sender(url).request_header
         response = api_client.get(
             url,
             content_type='',
             HTTP_AUTHORIZATION=auth,
             HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            data={'match_id': match_id},
         )
         assert response.status_code == status.HTTP_200_OK
 

--- a/wins/views/model_views.py
+++ b/wins/views/model_views.py
@@ -33,14 +33,14 @@ class StandardPagination(PageNumberPagination):
     """Standard pagination."""
 
     page_size = 25
-    page_size_query_param = "page-size"
+    page_size_query_param = 'page-size'
 
 
 class BigPagination(PageNumberPagination):
     """Big pagination."""
 
     page_size = 1000
-    page_size_query_param = "page-size"
+    page_size_query_param = 'page-size'
 
 
 class WinViewSet(AliceMixin, ModelViewSet):
@@ -52,12 +52,11 @@ class WinViewSet(AliceMixin, ModelViewSet):
     pagination_class = BigPagination
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filter_fields = ('id', 'user__id')
-    ordering_fields = ("pk",)
-    http_method_names = ("get", "post", "put", "patch")
+    ordering_fields = ('pk',)
+    http_method_names = ('get', 'post', 'put', 'patch')
 
     def _notify_if_complete(self, instance):
-        """ If the form is marked 'complete', email customer for response """
-
+        """If the form is marked 'complete', email customer for response."""
         if not instance.complete:
             return
 
@@ -89,31 +88,31 @@ class WinViewSet(AliceMixin, ModelViewSet):
 
 
 class LimitedWinViewSet(WinViewSet):
-    """ Limited view for customer response """
+    """Limited view for customer response."""
 
     serializer_class = LimitedWinSerializer
     permission_classes = (AllowAny,)
-    http_method_names = ("get",)
+    http_method_names = ('get',)
 
     def get_queryset(self):
-
+        """Allow for specific wins to be queried here."""
         # We only allow for specific wins to be queried here
-        if "pk" not in self.kwargs:
+        if 'pk' not in self.kwargs:
             return WinViewSet.get_queryset(self).none()
 
         # Limit records to wins that have not already been confirmed
         return WinViewSet.get_queryset(self).filter(
-            pk=self.kwargs["pk"],
-            confirmation__isnull=True
+            pk=self.kwargs['pk'],
+            confirmation__isnull=True,
         )
 
 
 class DetailsWinViewSet(WinViewSet):
-    """ Provides additional Win data for details view """
+    """Provides additional Win data for details view."""
 
     serializer_class = DetailWinSerializer
     permission_classes = (AllowAny,)
-    http_method_names = ("get",)
+    http_method_names = ('get',)
 
 
 class ConfirmationViewSet(AliceMixin, ModelViewSet):
@@ -125,12 +124,11 @@ class ConfirmationViewSet(AliceMixin, ModelViewSet):
     permission_classes = (AllowAny,)
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filter_class = CustomerResponseFilterSet
-    ordering_fields = ("pk",)
-    http_method_names = ("get", "post")
+    ordering_fields = ('pk',)
+    http_method_names = ('get', 'post')
 
     def perform_create(self, serializer):
-        """ Send officer notification when customer responds """
-
+        """Send officer notification when customer responds."""
         instance = serializer.save()
         notifications.send_officer_notification_of_customer_response(instance)
 
@@ -152,8 +150,8 @@ class BreakdownViewSet(AliceMixin, ModelViewSet):
     pagination_class = StandardPagination
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filter_fields = ('win__id',)
-    ordering_fields = ("pk",)
-    http_method_names = ("get", "post", "patch", "put", "delete")
+    ordering_fields = ('pk',)
+    http_method_names = ('get', 'post', 'patch', 'put', 'delete')
 
 
 class AdvisorViewSet(AliceMixin, ModelViewSet):
@@ -164,13 +162,14 @@ class AdvisorViewSet(AliceMixin, ModelViewSet):
     pagination_class = StandardPagination
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filter_fields = ('win__id',)
-    ordering_fields = ("pk",)
-    http_method_names = ("get", "post", "patch", "put", "delete")
+    ordering_fields = ('pk',)
+    http_method_names = ('get', 'post', 'patch', 'put', 'delete')
 
     def perform_destroy(self, instance):
         """
-        when Win is deleted, it's advisors get soft-deleted
-        but when a user deletes the advisor, want to delete it for real
+        When Win is deleted, it's advisors get soft-deleted.
+
+        But when a user deletes the advisor, want to delete it for real
         which requires overriding the standard method to give the
         `for_real` flag
         """


### PR DESCRIPTION
So that Data Hub can request for all match ids of source and merged companies at once and show correct wins on export tab.

API is changed from `wins/match/<match_id>` to `wins/match?match_id=1,2`

Validation is applied to make sure `match_id` query parameter is supplied all the times
And ids provided within that query param are all integers.