### PR TITLE
Sort sectors by name

### DIFF
--- a/wins/constants.py
+++ b/wins/constants.py
@@ -625,6 +625,8 @@ SECTORS = (
     (257, "Water"),
 )
 
+SECTORS = sorted(SECTORS, key=lambda data: data[1])
+
 TEAMS = (
     ("team", "Trade (TD or ST)"),
     ("investment", "Investment (ITFG or IG)"),


### PR DESCRIPTION
This change sorts sectors by name, allowing the sectors names to be changed in future with the list then rendering in alphabetical order rather than by id.