### PR TITLE
Sync Sector command

### DIFF
--- a/mi/management/commands/sync_sectors.py
+++ b/mi/management/commands/sync_sectors.py
@@ -13,8 +13,12 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
 
+    def add_arguments(self, parser):
+        parser.add_argument("--simulate", type=bool, default=False)
+        parser.add_argument("--disable_on", type=datetime.fromisoformat, default=datetime.now())
+
     def handle(self, *args, **options):
         sync_sectors = SyncSectors(
-            SectorModel, SECTORS, disable_on=datetime.now(), simulate=False
+            SectorModel, SECTORS, disable_on=options['disable_on'], simulate=options['simulate']
         )
         sync_sectors()

--- a/mi/management/commands/sync_sectors.py
+++ b/mi/management/commands/sync_sectors.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+import logging
+
+from django.core.management.base import BaseCommand
+
+
+from mi.models import Sector as SectorModel
+from mi.sync_sectors import SyncSectors
+from wins.constants import SECTORS
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        sync_sectors = SyncSectors(
+            SectorModel, SECTORS, disable_on=datetime.now(), simulate=False
+        )
+        sync_sectors()

--- a/mi/sync_sectors.py
+++ b/mi/sync_sectors.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 class SyncSectors:
 
     def __init__(self, sector_model, sectors, disable_on=None, simulate=False):
@@ -6,10 +11,13 @@ class SyncSectors:
         self.disable_on = disable_on
         self.simulate = simulate
 
-    def log(self, msg):
-        print(msg)
+    def log(self, msg, level=logging.INFO):
+        logger.log(level, msg)
 
     def __call__(self, *args, **kwargs):
+        self.process()
+
+    def process(self):
         self.add_new_sectors()
         self.update_existing_sectors()
         if self.disable_on:
@@ -23,7 +31,7 @@ class SyncSectors:
 
     def _update_sector_name(self, sector, sector_name):
         if sector.name != sector_name:
-            self.log(f'Updating Sector {sector.id}: [{sector.name}]')
+            self.log(f'Updating Sector {sector.id}: [{sector.name} to {sector_name}]')
         if self.simulate:
             return
         sector.name = sector_name

--- a/mi/sync_sectors.py
+++ b/mi/sync_sectors.py
@@ -1,0 +1,65 @@
+class SyncSectors:
+
+    def __init__(self, sector_model, sectors, disable_on=None, simulate=False):
+        self.sector_model = sector_model
+        self.sectors = sectors
+        self.disable_on = disable_on
+        self.simulate = simulate
+
+    def log(self, msg):
+        print(msg)
+
+    def __call__(self, *args, **kwargs):
+        self.add_new_sectors()
+        self.update_existing_sectors()
+        if self.disable_on:
+            self.disable_sectors()
+
+    def _get_sector(self, sector_id):
+        try:
+            return self.sector_model.objects.get(id=sector_id)
+        except self.sector_model.DoesNotExist:
+            return
+
+    def _update_sector_name(self, sector, sector_name):
+        if sector.name != sector_name:
+            self.log(f'Updating Sector {sector.id}: [{sector.name}]')
+        if self.simulate:
+            return
+        sector.name = sector_name
+        sector.save()
+
+    def _create_sector(self, sector_id, sector_name):
+        self.log(f'Creating Sector {sector_id}:  [{sector_name}]')
+        if self.simulate:
+            return
+        self.sector_model.objects.create(id=sector_id, name=sector_name)
+
+    def _disable_sector(self, sector):
+        self.log(f'Disabling Sector {sector.id}: [{sector.name}]')
+        if self.simulate:
+            return
+        sector.disabled_on = self.disable_on
+        sector.save()
+
+    def add_new_sectors(self):
+        for sector_id, sector_name in self.sectors:
+            sector = self._get_sector(sector_id)
+            if not sector:
+                self._create_sector(sector_id, sector_name)
+
+    def update_existing_sectors(self):
+        for sector_id, sector_name in self.sectors:
+            sector = self._get_sector(sector_id)
+            if not sector:
+                self.log(f'Sector {sector_id}: DOES NOT EXIST [{sector_name}]')
+            else:
+                self._update_sector_name(sector, sector_name)
+
+    def disable_sectors(self):
+        sector_ids = list(dict(self.sectors).keys())
+        deprecated_sectors = self.sector_model.objects.exclude(id__in=sector_ids).filter(
+            disabled_on__isnull=True
+        )
+        for sector in deprecated_sectors:
+            self._disable_sector(sector)

--- a/mi/tests/test_sync_sectors.py
+++ b/mi/tests/test_sync_sectors.py
@@ -1,0 +1,128 @@
+from unittest import mock
+from datetime import datetime
+
+import pytest
+from freezegun import freeze_time
+
+from mi.sync_sectors import SyncSectors
+from mi.models import Sector
+
+pytestmark = pytest.mark.django_db
+
+EXISTING_SECTOR = ('133', 'Energy')
+EXISTING_SECTOR_2 = ('134', 'Environment')
+EXISTING_SECTOR_WITH_ALT_NAME = ('133', 'Renewable energy')
+NEW_SECTOR = ('1000', 'Pie makers')
+
+
+@pytest.mark.parametrize(
+    'disable_on,',
+    (
+        True,  None,
+    ),
+)
+@mock.patch('mi.sync_sectors.SyncSectors.disable_sectors')
+@mock.patch('mi.sync_sectors.SyncSectors.update_existing_sectors')
+@mock.patch('mi.sync_sectors.SyncSectors.add_new_sectors')
+def test_process(mock_add_new, mock_update, mock_disable, disable_on):
+    mock_add_new.return_value = None
+    mock_update.return_value = None
+    mock_disable.return_value = None
+    disable_is_called = False
+    if disable_on:
+        disable_on = datetime.today()
+        disable_is_called = True
+    sync_sectors = SyncSectors(
+        Sector, {}, disable_on=disable_on
+    )
+    sync_sectors()
+    assert mock_add_new.called is True
+    assert mock_update.called is True
+    assert mock_disable.called is disable_is_called
+
+
+@pytest.mark.parametrize(
+    'sectors,expected_log,simulate',
+    (
+        (
+            [NEW_SECTOR], 'Creating Sector 1000:  [Pie makers]', False,
+        ),
+        (
+            [NEW_SECTOR], 'Creating Sector 1000:  [Pie makers]', True
+        ),
+        (
+            [EXISTING_SECTOR], '', False,
+        ),
+    ),
+)
+def test_add_new_sectors(sectors, expected_log, simulate, caplog):
+    sync_sectors = SyncSectors(
+        Sector, sectors, simulate=simulate,
+    )
+    sync_sectors.add_new_sectors()
+    exists = not simulate
+    assert_sectors(sectors, exists)
+    assert expected_log in caplog.text
+
+
+@pytest.mark.parametrize(
+    'sectors,expected_log,simulate',
+    (
+        (
+            [EXISTING_SECTOR_WITH_ALT_NAME], 'Updating Sector 133: [Energy to Renewable energy]', False,
+        ),
+        (
+            [EXISTING_SECTOR_WITH_ALT_NAME], 'Updating Sector 133: [Energy to Renewable energy]', True
+        ),
+    ),
+)
+def test_update_existing_sector(sectors, expected_log, simulate, caplog):
+    assert_sectors(sectors, True, ignore_name=True)
+    sync_sectors = SyncSectors(
+        Sector, sectors, simulate=simulate,
+    )
+    sync_sectors.update_existing_sectors()
+    exists = not simulate
+    assert_sectors(sectors, exists)
+    assert expected_log in caplog.text
+
+
+@pytest.mark.parametrize(
+    'sectors,expected_log,simulate',
+    (
+        (
+            [EXISTING_SECTOR], 'Disabling Sector 133: [Energy]', False,
+        ),
+        (
+            [EXISTING_SECTOR], 'Disabling Sector 133: [Energy]', True
+        ),
+    ),
+)
+@freeze_time('2020-01-01 12:00:00')
+def test_disable_sectors(sectors, expected_log, simulate, caplog):
+    assert_sectors(sectors, True)
+    sync_sectors = SyncSectors(
+        Sector, sectors, simulate=simulate, disable_on=datetime.now()
+    )
+    sync_sectors.disable_sectors()
+    assert expected_log not in caplog.text
+    assert_sectors(sectors, True, extra_filters={'disabled_on__isnull': True})
+    if not simulate:
+        assert_sectors(
+            [EXISTING_SECTOR_2], True, extra_filters={'disabled_on': datetime.now()}
+        )
+    else:
+        assert_sectors(
+            [EXISTING_SECTOR_2], True, extra_filters={'disabled_on__isnull': True}
+        )
+
+
+def assert_sectors(sectors, exists, extra_filters=None, ignore_name=False):
+    sectors = dict(sectors)
+    for sector_id, sector_name in sectors.items():
+        filters = {'id': sector_id}
+        if not ignore_name:
+            filters['name'] = sector_name
+        if extra_filters:
+            filters.update(**extra_filters)
+        assert Sector.objects.filter(**filters).exists() == exists


### PR DESCRIPTION
This PR adds a sync sector command that takes what is in the constant file and updates the database so the two are in sync.

This has been written in a way where the logic to sync the sectors can also be used from within a migration see https://github.com/uktrade/export-wins-data/pull/995

The plan is to release every part we can prior to the big bang of updating everything. This script is part of that.

If you run the command now with `--simulate` it will show that one sector is constants file but not in the database (id 6, test widgerts) 

