### PR TITLE
Fix for update sector_sector_team cmd when sector has multiple teams

### DIFF
--- a/mi/management/commands/update_sector_sector_team.py
+++ b/mi/management/commands/update_sector_sector_team.py
@@ -23,12 +23,12 @@ class Command(CSVBaseCommand):
 
     def is_update_required(self, sector, sector_teams):
         current_teams = list(sector.sector_team.all())
+        if len(current_teams) != len(sector_teams):
+            return True
+
         for team in sector_teams:
             if team not in current_teams:
                 return True
-
-        if len(current_teams) != len(sector_teams):
-            return False
         return False
 
     def get_sector_teams(self, sector_team_ids):


### PR DESCRIPTION
This fixes an issue where a sector that has multiple teams in the db was not being updated properly.