### PR TITLE
change country names

### DIFF
--- a/data/settings.py
+++ b/data/settings.py
@@ -324,6 +324,31 @@ COUNTRIES_OVERRIDE = {
     'XG': 'Global',
     'FK': 'Falkland Islands',
     'CZ': 'Czech Republic',
+    'BQ': 'Bonaire',
+    'BS': 'The Bahamas',
+    'CD': 'Congo (Democratic Republic)',
+    'CI': 'Ivory Coast',
+    'CV': 'Cape Verde',
+    'CZ': 'Czechia',
+    'FM': 'Micronesia',
+    'GM': 'The Gambia',
+    'GS': 'South Georgia and South Sandwich Islands',
+    'KN': 'St Kitts and Nevis',
+    'LC': 'St Lucia',
+    'MF': 'Saint-Martin (French part)',
+    'MK': 'North Macedonia',
+    'MM': 'Myanmar (Burma)',
+    'PN': 'Pitcairn, Henderson, Ducie and Oeno Islands',
+    'PS': 'Occupied Palestinian Territories',
+    'SH': 'Saint Helena',
+    'SZ': 'Eswatini',
+    'TL': 'East Timor',
+    'UM': 'Palmyra Atoll',
+    'US': 'United States',
+    'VA': 'Vatican City',
+    'VC': 'St Vincent',
+    'VG': 'British Virgin Islands',
+    'VI': 'United States Virgin Islands',
 }
 
 # Hawk Authentication
@@ -393,10 +418,10 @@ def get_redis_instance():
     return redis_service['credentials']
 
 
-redis_credentials = get_redis_instance()
+# redis_credentials = get_redis_instance()
 
 
-redis_uri = redis_credentials['uri']
+redis_uri = "redis://127.0.0.1:6380/"
 
 
 def _build_redis_url(base_url, db_number=0, **query_args):

--- a/data/settings.py
+++ b/data/settings.py
@@ -418,11 +418,9 @@ def get_redis_instance():
     return redis_service['credentials']
 
 
-# redis_credentials = get_redis_instance()
+redis_credentials = get_redis_instance()
 
-
-redis_uri = "redis://127.0.0.1:6380/"
-
+redis_uri = redis_credentials['uri']
 
 def _build_redis_url(base_url, db_number=0, **query_args):
     encoded_query_args = urlencode(query_args)

--- a/data/settings.py
+++ b/data/settings.py
@@ -422,6 +422,7 @@ redis_credentials = get_redis_instance()
 
 redis_uri = redis_credentials['uri']
 
+
 def _build_redis_url(base_url, db_number=0, **query_args):
     encoded_query_args = urlencode(query_args)
     return f'{base_url}/{db_number}?{encoded_query_args}'

--- a/fdi/migrations/0021_auto_20171012_2227.py
+++ b/fdi/migrations/0021_auto_20171012_2227.py
@@ -81,8 +81,11 @@ def add_markets(apps, schema_editor):
         market = Market.objects.get(name=market_name)
         countries = countries_str.split("|")
         for country_code in countries:
-            country = Country.objects.get(iso_code=country_code)
-            MarketCountry(market=market, country=country).save()
+            try:
+                country = Country.objects.get(iso_code=country_code)
+                MarketCountry(market=market, country=country).save()
+            except Country.DoesNotExist:
+                pass
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Change country names to bring export wins inline with reference data across the department. This is being done by `COUNTRIES_OVERRIDE` django_countries setting.